### PR TITLE
Still some tweaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,10 +12,11 @@
 /Debug
 
 # CMake
+/build
 /CMakeFiles
 /cmake_install.cmake
 /CMakeCache.txt
-/UltimateAnticheat.dir
+/Ultimate*
 /bin
 /ZERO_CHECK.vcxproj
 /ZERO_CHECK.vcxproj.filters

--- a/API/API.cpp
+++ b/API/API.cpp
@@ -24,13 +24,13 @@ Error API::Initialize(AntiCheat* AC, string licenseKey, bool isServerAvailable)
 	}
 	else //bad parent process detected, or parent process mismatch, shut down the program (and optionally report the error to the server)
 	{
-		Logger::logfw("UltimateAnticheat.log", Detection, L"Parent process '%s' was not whitelisted, shutting down program!", Process::GetProcessName(Process::GetParentProcessId()).c_str());
+		Logger::logfw(Detection, L"Parent process '%s' was not whitelisted, shutting down program!", Process::GetProcessName(Process::GetParentProcessId()).c_str());
 		errorCode = Error::PARENT_PROCESS_MISMATCH;
 	}
 
 	if (isServerAvailable)
 	{
-		Logger::logf("UltimateAnticheat.log", Info, "Starting networking component...");
+		Logger::logf(Info, "Starting networking component...");
 
 		auto client = AC->GetNetworkClient().lock();
 
@@ -44,13 +44,13 @@ Error API::Initialize(AntiCheat* AC, string licenseKey, bool isServerAvailable)
 		}
 		else
 		{
-			Logger::logf("UltimateAnticheat.log", Err, "Could not fetch/lock network client, exiting...");
+			Logger::logf(Err, "Could not fetch/lock network client, exiting...");
 			return Error::NULL_MEMORY_REFERENCE;
 		}
 	}
 	else
 	{
-		Logger::logf("UltimateAnticheat.log", Info, "Networking is currently disabled, no heartbeats will occur");
+		Logger::logf(Info, "Networking is currently disabled, no heartbeats will occur");
 	}
 
 end:	
@@ -90,7 +90,7 @@ Error API::Cleanup(AntiCheat* AC)
 	}
 	else
 	{
-		Logger::logf("UltimateAnticheat.log", Err, "Couldn't fetch/lock netclient @  API::Cleanup");
+		Logger::logf(Err, "Couldn't fetch/lock netclient @  API::Cleanup");
 		return Error::NULL_MEMORY_REFERENCE;
 	}
 
@@ -110,17 +110,17 @@ Error API::LaunchDefenses(AntiCheat* AC) //currently in the process to split the
 
 	if (AC->GetBarrier()->DeployBarrier() == Error::OK) //activate all techniques to stop cheaters
 	{
-		Logger::logf("UltimateAnticheat.log", Info, " Barrier techniques were applied successfully!");
+		Logger::logf(Info, " Barrier techniques were applied successfully!");
 	}
 	else
 	{
-		Logger::logf("UltimateAnticheat.log", Err, "Could not initialize the barrier @ API::LaunchBasicTests");
+		Logger::logf(Err, "Could not initialize the barrier @ API::LaunchBasicTests");
 		errorCode = Error::CANT_APPLY_TECHNIQUE;
 	}
 
 	if (!AC->GetMonitor()->StartMonitor()) //start looped detections
 	{
-		Logger::logf("UltimateAnticheat.log", Err, "Could not initialize the barrier @ API::LaunchBasicTests");
+		Logger::logf(Err, "Could not initialize the barrier @ API::LaunchBasicTests");
 		errorCode = Error::CANT_STARTUP;
 	}
 
@@ -135,7 +135,7 @@ Error API::LaunchDefenses(AntiCheat* AC) //currently in the process to split the
 
 	if (!Process::CheckParentProcess(AC->GetMonitor()->GetProcessObj()->GetParentName())) //parent process check, the parent process would normally be set using our API methods
 	{
-		Logger::logf("UltimateAnticheat.log", Detection, "Parent process was not in whitelist! cheater detected!\n");
+		Logger::logf(Detection, "Parent process was not in whitelist! cheater detected!\n");
 		errorCode = Error::PARENT_PROCESS_MISMATCH;
 	}
 
@@ -160,13 +160,13 @@ Error API::Dispatch(AntiCheat* AC, DispatchCode code)
 			{
 				if (LaunchDefenses(AC) != Error::OK)
 				{
-					Logger::logf("UltimateAnticheat.log", Warning, " At least one technique experienced abnormal behavior when launching tests.");
+					Logger::logf(Warning, " At least one technique experienced abnormal behavior when launching tests.");
 					return Error::CANT_APPLY_TECHNIQUE;
 				}
 			}
 			else
 			{
-				Logger::logf("UltimateAnticheat.log", Warning, "Couldn't start up, either the parent process was wrong or no auth server was present.");
+				Logger::logf(Warning, "Couldn't start up, either the parent process was wrong or no auth server was present.");
 				return Error::CANT_CONNECT;
 			}
 		}break;
@@ -186,7 +186,7 @@ Error API::Dispatch(AntiCheat* AC, DispatchCode code)
 		} break;
 
 		default:
-			Logger::logf("UltimateAnticheat.log", Warning, "Unrecognized dispatch code @ API::Dispatch: %d\n", code);
+			Logger::logf(Warning, "Unrecognized dispatch code @ API::Dispatch: %d\n", code);
 			break;
 	};
 

--- a/API/API.cpp
+++ b/API/API.cpp
@@ -24,7 +24,7 @@ Error API::Initialize(AntiCheat* AC, string licenseKey, bool isServerAvailable)
 	}
 	else //bad parent process detected, or parent process mismatch, shut down the program (and optionally report the error to the server)
 	{
-		Logger::logfw("UltimateAnticheat.log", Detection, L"Parent process was not whitelisted, shutting down program!");
+		Logger::logfw("UltimateAnticheat.log", Detection, L"Parent process '%s' was not whitelisted, shutting down program!", Process::GetProcessName(Process::GetParentProcessId()).c_str());
 		errorCode = Error::PARENT_PROCESS_MISMATCH;
 	}
 

--- a/AntiCheat.hpp
+++ b/AntiCheat.hpp
@@ -26,7 +26,7 @@ public:
 	{		
 		if (config == nullptr)
 		{
-			Logger::logf("UltimateAnticheat.log", Err, "Settings pointer was NULL @ AntiCheat::AntiCheat");
+			Logger::logf(Err, "Settings pointer was NULL @ AntiCheat::AntiCheat");
 			return;
 		}
 		
@@ -42,7 +42,7 @@ public:
 		}
 		catch (const std::bad_alloc& e)
 		{
-			Logger::logf("UltimateAnticheat.log", Err, "Critical allocation failure in AntiCheat::AntiCheat: %s", e.what());
+			Logger::logf(Err, "Critical allocation failure in AntiCheat::AntiCheat: %s", e.what());
 			std::terminate();  //do not allow proceed if any pointers fail to alloc
 		}
 
@@ -52,7 +52,7 @@ public:
 			
 			if (!GetFullPathName(Config->GetKMDriverPath().c_str(), MAX_PATH, absolutePath, nullptr))
 			{
-				Logger::logf("UltimateAnticheat.log", Err, "Could not get absolute path from driver relative path, shutting down.");
+				Logger::logf(Err, "Could not get absolute path from driver relative path, shutting down.");
 				std::terminate();  //do not allow proceed since config is set to using driver but we cannot find the driver
 			}
 				
@@ -61,17 +61,17 @@ public:
 
 			if (driverCertSubject.size() == 0 || driverCertSubject != DriverSignerSubject) //check if driver cert has correct sign subject
 			{
-				Logger::logf("UltimateAnticheat.log", Err, "Driver certificate subject/signer was not correct, shutting down...");
+				Logger::logf(Err, "Driver certificate subject/signer was not correct, shutting down...");
 				std::terminate();
 			}
 
 			if (!Services::LoadDriver(Config->GetKMDriverName().c_str(), absolutePath))
 			{
-				Logger::logf("UltimateAnticheat.log", Err, "Could not get load the driver, shutting down.");
+				Logger::logf(Err, "Could not get load the driver, shutting down.");
 				std::terminate();  //do not allow to proceed since config is set to using driver
 			}
 
-			Logger::logfw("UltimateAnticheat.log", Info, L"Loaded driver: %s from path %s", Config->GetKMDriverName().c_str(), absolutePath);
+			Logger::logfw(Info, L"Loaded driver: %s from path %s", Config->GetKMDriverName().c_str(), absolutePath);
 		}
 
 	}
@@ -82,16 +82,16 @@ public:
 		{
 			if (!Services::UnloadDriver(Config->GetKMDriverName()))
 			{
-				Logger::logf("UltimateAnticheat.log", Warning, "Failed to unload kernelmode driver!");
+				Logger::logf(Warning, "Failed to unload kernelmode driver!");
 			}
 		}
 		if (API::Dispatch(this, API::DispatchCode::CLIENT_EXIT) == Error::OK) //clean up memory & threads -> this will soon be removed once all threads and objects are changed to smart pointers
 	    {
-        	Logger::logf("UltimateAnticheat.log", Info, " Cleanup successful. Shutting down program");
+        	Logger::logf(Info, " Cleanup successful. Shutting down program");
     	}
 	    else
     	{
-        	Logger::logf("UltimateAnticheat.log", Err, "Cleanup unsuccessful... Shutting down program");
+        	Logger::logf(Err, "Cleanup unsuccessful... Shutting down program");
     	}
 	}
 
@@ -139,22 +139,22 @@ __forceinline bool AntiCheat::IsAnyThreadSuspended()
 {
 	if (Monitor->GetMonitorThread()!= nullptr && Thread::IsThreadSuspended(Monitor->GetMonitorThread()->GetId()))
 	{
-		Logger::logf("UltimateAnticheat.log", Detection, "Monitor was found suspended! Abnormal program execution.");
+		Logger::logf(Detection, "Monitor was found suspended! Abnormal program execution.");
 		return true;
 	}
 	else if (Monitor->GetProcessCreationMonitorThread() != nullptr && Thread::IsThreadSuspended(Monitor->GetProcessCreationMonitorThread()->GetId()))
 	{
-		Logger::logf("UltimateAnticheat.log", Detection, "Monitor's process creation thread was found suspended! Abnormal program execution.");
+		Logger::logf(Detection, "Monitor's process creation thread was found suspended! Abnormal program execution.");
 		return true;
 	}
 	else if (Config->bUseAntiDebugging && AntiDebugger->GetDetectionThread() != nullptr && Thread::IsThreadSuspended(AntiDebugger->GetDetectionThread()->GetId()))
 	{
-		Logger::logf("UltimateAnticheat.log", Detection, "Anti-debugger was found suspended! Abnormal program execution.");
+		Logger::logf(Detection, "Anti-debugger was found suspended! Abnormal program execution.");
 		return true;
 	}
 	else if (NetworkClient->GetRecvThread() != nullptr && Thread::IsThreadSuspended(NetworkClient->GetRecvThread()->GetId()))
 	{
-		Logger::logf("UltimateAnticheat.log", Detection, "Netclient comms thread was found suspended! Abnormal program execution.");
+		Logger::logf(Detection, "Netclient comms thread was found suspended! Abnormal program execution.");
 		return true;
 	}
 

--- a/AntiDebug/AntiDebugger.cpp
+++ b/AntiDebug/AntiDebugger.cpp
@@ -12,24 +12,24 @@ void Debugger::AntiDebug::StartAntiDebugThread()
 	{
 		if (!settings->bUseAntiDebugging)
 		{
-			Logger::logf("UltimateAnticheat.log", Info, "Anti-Debugger was disabled in settings, debugging will be allowed");
+			Logger::logf(Info, "Anti-Debugger was disabled in settings, debugging will be allowed");
 			return;
 		}
 	}
 	else
 	{
-		Logger::logf("UltimateAnticheat.log", Warning, "Settings were NULL or failed to lock weak_ptr<Settings> @ Debugger::AntiDebug::StartAntiDebugThread");
+		Logger::logf(Warning, "Settings were NULL or failed to lock weak_ptr<Settings> @ Debugger::AntiDebug::StartAntiDebugThread");
 	}
 
 	this->DetectionThread = make_unique<Thread>((LPTHREAD_START_ROUTINE)Debugger::AntiDebug::CheckForDebugger, (LPVOID)this, true, true);
 
 	if (this->DetectionThread->GetHandle() == INVALID_HANDLE_VALUE || this->DetectionThread->GetHandle() == NULL)
 	{
-		Logger::logf("UltimateAnticheat.log", Err, "Couldn't start anti-debug thread @ Debugger::AntiDebug::StartAntiDebugThread");
+		Logger::logf(Err, "Couldn't start anti-debug thread @ Debugger::AntiDebug::StartAntiDebugThread");
 		//optionally shut down here if thread creation fails
 	}
 
-	Logger::logf("UltimateAnticheat.log", Info, "Created Debugger detection thread with Id: %d", this->DetectionThread->GetId());
+	Logger::logf(Info, "Created Debugger detection thread with Id: %d", this->DetectionThread->GetId());
 }
 
 /*
@@ -39,13 +39,13 @@ void Debugger::AntiDebug::CheckForDebugger(LPVOID AD)
 {
 	if (AD == nullptr)
 	{
-		Logger::logf("UltimateAnticheat.log", Err, "AntiDbg class was NULL @ CheckForDebugger");
+		Logger::logf(Err, "AntiDbg class was NULL @ CheckForDebugger");
 		return;
 	}
 
 	Debugger::AntiDebug* AntiDbg = reinterpret_cast<Debugger::AntiDebug*>(AD);
 
-	Logger::logf("UltimateAnticheat.log", Info, "STARTED Debugger detection thread");
+	Logger::logf(Info, "STARTED Debugger detection thread");
 
 	bool MonitoringDebugger = true;
 
@@ -55,13 +55,13 @@ void Debugger::AntiDebug::CheckForDebugger(LPVOID AD)
 	{
 		if (AntiDbg == NULL)
 		{
-			Logger::logf("UltimateAnticheat.log", Err, "AntiDbg class was NULL @ CheckForDebugger");
+			Logger::logf(Err, "AntiDbg class was NULL @ CheckForDebugger");
 			return;
 		}
 
 		if (AntiDbg->DetectionThread->IsShutdownSignalled())
 		{
-			Logger::logf("UltimateAnticheat.log", Info, "Shutting down Debugger detection thread with Id: %d", AntiDbg->DetectionThread->GetId());
+			Logger::logf(Info, "Shutting down Debugger detection thread with Id: %d", AntiDbg->DetectionThread->GetId());
 			return; //exit thread
 		}
 
@@ -69,7 +69,7 @@ void Debugger::AntiDebug::CheckForDebugger(LPVOID AD)
 
 		if (CheckHardwareRegistersThread == INVALID_HANDLE_VALUE || CheckHardwareRegistersThread == NULL)
 		{
-			Logger::logf("UltimateAnticheat.log", Warning, "Failed to create new thread to call _IsHardwareDebuggerPresent: %d", GetLastError());
+			Logger::logf(Warning, "Failed to create new thread to call _IsHardwareDebuggerPresent: %d", GetLastError());
 		}
 		else
 		{
@@ -78,7 +78,7 @@ void Debugger::AntiDebug::CheckForDebugger(LPVOID AD)
 
 		if (AntiDbg->RunDetectionFunctions())
 		{
-			Logger::logf("UltimateAnticheat.log", Info, "Atleast one debugger detection function caught a debugger!"); //optionally, iterate over DetectedMethods list
+			Logger::logf(Info, "Atleast one debugger detection function caught a debugger!"); //optionally, iterate over DetectedMethods list
 		}
 
 		Sleep(MonitorLoopDelayMS);
@@ -93,7 +93,7 @@ void Debugger::AntiDebug::_IsHardwareDebuggerPresent(LPVOID AD)
 {
 	if (AD == nullptr)
 	{
-		Logger::logf("UltimateAnticheat.log", Err, "AntiDbg class was NULL @ _IsHardwareDebuggerPresent");
+		Logger::logf(Err, "AntiDbg class was NULL @ _IsHardwareDebuggerPresent");
 		return;
 	}
 
@@ -105,7 +105,7 @@ void Debugger::AntiDebug::_IsHardwareDebuggerPresent(LPVOID AD)
 	HANDLE hThreadSnap = CreateToolhelp32Snapshot(TH32CS_SNAPTHREAD, 0);
 	if (hThreadSnap == INVALID_HANDLE_VALUE)
 	{
-		Logger::logf("UltimateAnticheat.log", Err, "Error: unable to create toolhelp snapshot: %d\n", GetLastError());
+		Logger::logf(Err, "Error: unable to create toolhelp snapshot: %d\n", GetLastError());
 		return;
 	}
 
@@ -121,7 +121,7 @@ void Debugger::AntiDebug::_IsHardwareDebuggerPresent(LPVOID AD)
 
 				if (hThread == NULL)
 				{
-					Logger::logf("UltimateAnticheat.log", Warning, "Error: unable to OpenThread on thread with id %d\n", te32.th32ThreadID);
+					Logger::logf(Warning, "Error: unable to OpenThread on thread with id %d\n", te32.th32ThreadID);
 					continue;
 				}
 
@@ -134,7 +134,7 @@ void Debugger::AntiDebug::_IsHardwareDebuggerPresent(LPVOID AD)
 				{
 					if (context.Dr0 || context.Dr1 || context.Dr2 || context.Dr3 || context.Dr6 || context.Dr7)
 					{
-						Logger::logf("UltimateAnticheat.log", Detection, "Found at least one debug register enabled (hardware debugging)");
+						Logger::logf(Detection, "Found at least one debug register enabled (hardware debugging)");
 						ResumeThread(hThread);
 
 						if (!AntiDbg->Flag(Detections::HARDWARE_REGISTERS))
@@ -148,7 +148,7 @@ void Debugger::AntiDebug::_IsHardwareDebuggerPresent(LPVOID AD)
 				}
 				else
 				{
-					Logger::logf("UltimateAnticheat.log", Err, "GetThreadContext failed with: %d", GetLastError());
+					Logger::logf(Err, "GetThreadContext failed with: %d", GetLastError());
 					ResumeThread(hThread);
 					CloseHandle(hThread);
 					continue;
@@ -161,7 +161,7 @@ void Debugger::AntiDebug::_IsHardwareDebuggerPresent(LPVOID AD)
 	}
 	else
 	{
-		Logger::logf("UltimateAnticheat.log", Err, "Thread32First Failed: %d\n", GetLastError());
+		Logger::logf(Err, "Thread32First Failed: %d\n", GetLastError());
 		return;
 	}
 
@@ -206,13 +206,13 @@ bool Debugger::AntiDebug::Flag(Debugger::Detections flag)
 	{
 		if (this->GetNetClient()->FlagCheater(DetectionFlags::DEBUGGER) != Error::OK) //the type of debugger doesn't really matter at the server-side, we can optionally modify the outbound packet to make debugger detections more granular
 		{
-			Logger::logf("UltimateAnticheat.log", Err, "Failed to notify server of caught debugger status");
+			Logger::logf(Err, "Failed to notify server of caught debugger status");
 			return false;
 		}
 	}
 	else
 	{
-		Logger::logf("UltimateAnticheat.log", Err, "NetClient was NULL @ AntiDebug::Flag");
+		Logger::logf(Err, "NetClient was NULL @ AntiDebug::Flag");
 		return false;
 	}
 
@@ -228,7 +228,7 @@ bool Debugger::AntiDebug::PreventWindowsDebuggers()
 
 	if (!ntdll)
 	{
-		Logger::logf("UltimateAnticheat.log", Err, "Failed to find ntdll.dll @ AntiDebug::PreventWindowsDebuggers");
+		Logger::logf(Err, "Failed to find ntdll.dll @ AntiDebug::PreventWindowsDebuggers");
 		return false;
 	}
 
@@ -247,7 +247,7 @@ bool Debugger::AntiDebug::PreventWindowsDebuggers()
 			}
 			__except(EXCEPTION_EXECUTE_HANDLER)
 			{
-				Logger::logf("UltimateAnticheat.log", Err, "Failed to patch over DbgBreakpoint @ AntiDebug::PreventWindowsDebuggers");
+				Logger::logf(Err, "Failed to patch over DbgBreakpoint @ AntiDebug::PreventWindowsDebuggers");
 				return false;
 			}
 
@@ -265,7 +265,7 @@ bool Debugger::AntiDebug::PreventWindowsDebuggers()
 			}
 			__except (EXCEPTION_EXECUTE_HANDLER)
 			{
-				Logger::logf("UltimateAnticheat.log", Err, "Failed to patch over DbgUiRemoteBreakin @ AntiDebug::PreventWindowsDebuggers");
+				Logger::logf(Err, "Failed to patch over DbgUiRemoteBreakin @ AntiDebug::PreventWindowsDebuggers");
 				return false;
 			}
 

--- a/AntiDebug/AntiDebugger.hpp
+++ b/AntiDebug/AntiDebugger.hpp
@@ -38,7 +38,7 @@ namespace Debugger
         {
             if (!PreventWindowsDebuggers())
             {
-                Logger::logf("UltimateAnticheat.log", Warning, "Failed to apply anti-debugging technique @ AntiDebug()");
+                Logger::logf(Warning, "Failed to apply anti-debugging technique @ AntiDebug()");
             }
         }
 

--- a/AntiDebug/DebuggerDetections.cpp
+++ b/AntiDebug/DebuggerDetections.cpp
@@ -18,7 +18,7 @@ bool DebuggerDetections::_IsKernelDebuggerPresent()
 
 	if (hModule == NULL)
 	{
-		Logger::logf("UltimateAnticheat.log", Err, "Error fetching module ntdll.dll @ _IsKernelDebuggerPresent: %d", GetLastError());
+		Logger::logf(Err, "Error fetching module ntdll.dll @ _IsKernelDebuggerPresent: %d", GetLastError());
 		return false;
 	}
 
@@ -32,7 +32,7 @@ bool DebuggerDetections::_IsKernelDebuggerPresent()
 		{
 			if (!Flag(Detections::KERNEL_DEBUGGER))
 			{
-				Logger::logf("UltimateAnticheat.log", Warning, "Failed to notify server of debugging method (server may be offline or duplicate entry)");
+				Logger::logf(Warning, "Failed to notify server of debugging method (server may be offline or duplicate entry)");
 			}
 
 			return true;
@@ -55,7 +55,7 @@ bool DebuggerDetections::_IsKernelDebuggerPresent_SharedKData()
 
 		if (!Flag(Detections::KERNEL_DEBUGGER))
 		{
-			Logger::logf("UltimateAnticheat.log", Warning, "Failed to notify server of debugging method (server may be offline or duplicate entry)");
+			Logger::logf(Warning, "Failed to notify server of debugging method (server may be offline or duplicate entry)");
 		}
 	}
 
@@ -92,7 +92,7 @@ bool DebuggerDetections::_IsDebuggerPresent_HeapFlags()
 		}
 		__except (EXCEPTION_EXECUTE_HANDLER)
 		{
-			Logger::logf("UltimateAnticheat.log", Warning, "Failed to dereference heapForceFlagsPtr @ _IsDebuggerPresent_HeapFlags");
+			Logger::logf(Warning, "Failed to dereference heapForceFlagsPtr @ _IsDebuggerPresent_HeapFlags");
 			return false;
 		}
 	}
@@ -154,7 +154,7 @@ bool DebuggerDetections::_IsDebuggerPresent_DbgBreak()
 		return false;
 	}
 
-	Logger::logf("UltimateAnticheat.log", Info, "Calling __fastfail() to prevent further execution since a debugger was found running.");
+	Logger::logf(Info, "Calling __fastfail() to prevent further execution since a debugger was found running.");
 
 	if (!Flag(Detections::DBG_BREAK))
 	{//optionally take further action, `Flag` will already log a warning
@@ -191,7 +191,7 @@ bool DebuggerDetections::_IsDebuggerPresent_VEH()
 
 			if (!VirtualProtect((void*)veh_addr, 1, PAGE_EXECUTE_READWRITE, &dwOldProt))
 			{
-				Logger::logf("UltimateAnticheat.log", Warning, "VirtualProtect failed @ _IsDebuggerPresent_VEH");
+				Logger::logf(Warning, "VirtualProtect failed @ _IsDebuggerPresent_VEH");
 				return true; //return true since we found the routine, even though we can't patch over it. if virtualprotect fails, the program will probably crash if trying to patch it
 			}
 
@@ -199,12 +199,12 @@ bool DebuggerDetections::_IsDebuggerPresent_VEH()
 
 			if (!VirtualProtect((void*)veh_addr, 1, dwOldProt, &dwOldProt)) //change back to old prot's
 			{
-				Logger::logf("UltimateAnticheat.log", Warning, "VirtualProtect failed @ _IsDebuggerPresent_VEH");
+				Logger::logf(Warning, "VirtualProtect failed @ _IsDebuggerPresent_VEH");
 			}
 
 			if (Process::ChangeModuleName(L"vehdebug-x86_64.dll", L"STOP_CHEATING")) //change the vehdebug module name to something else for fun
 			{
-				Logger::logf("UltimateAnticheat.log", Info, "Changed module name of vehdebug-x86_64.dll to STOP_CHEATING to prevent VEH debugging.");
+				Logger::logf(Info, "Changed module name of vehdebug-x86_64.dll to STOP_CHEATING to prevent VEH debugging.");
 			}
 		}
 	}
@@ -268,12 +268,12 @@ bool DebuggerDetections::_IsDebuggerPresent_DebugPort()
 		}
 		else
 		{
-			Logger::logf("UltimateAnticheat.log", Warning, "Failed to fetch NtQueryInformationProcess address @ _IsDebuggerPresent_DebugPort ");
+			Logger::logf(Warning, "Failed to fetch NtQueryInformationProcess address @ _IsDebuggerPresent_DebugPort ");
 		}
 	}
 	else
 	{
-		Logger::logf("UltimateAnticheat.log", Warning, "Failed to fetch ntdll.dll address @ _IsDebuggerPresent_DebugPort ");
+		Logger::logf(Warning, "Failed to fetch ntdll.dll address @ _IsDebuggerPresent_DebugPort ");
 	}
 
 	return false;
@@ -310,7 +310,7 @@ bool DebuggerDetections::_IsDebuggerPresent_ProcessDebugFlags()
 	}
 	else
 	{
-		Logger::logf("UltimateAnticheat.log", Warning, "Failed to fetch ntdll.dll address @ _IsDebuggerPresent_ProcessDebugFlags ");
+		Logger::logf(Warning, "Failed to fetch ntdll.dll address @ _IsDebuggerPresent_ProcessDebugFlags ");
 	}
 	return false;
 }
@@ -340,7 +340,7 @@ bool DebuggerDetections::_ExitCommonDebuggers()
 
 			if (K32Base == NULL)
 			{
-				Logger::logf("UltimateAnticheat.log", Warning, "Failed to fetch kernel32.dll address @ _ExitCommonDebuggers ");
+				Logger::logf(Warning, "Failed to fetch kernel32.dll address @ _ExitCommonDebuggers ");
 				return false;
 			}
 
@@ -348,7 +348,7 @@ bool DebuggerDetections::_ExitCommonDebuggers()
 
 			if (ExitProcessAddr == NULL)
 			{
-				Logger::logf("UltimateAnticheat.log", Warning, "Failed to fetch ExitProcess address @ _ExitCommonDebuggers ");
+				Logger::logf(Warning, "Failed to fetch ExitProcess address @ _ExitCommonDebuggers ");
 				return false;
 			}
 
@@ -359,7 +359,7 @@ bool DebuggerDetections::_ExitCommonDebuggers()
 			if (remoteProcHandle)
 			{
 				HANDLE RemoteThread = CreateRemoteThread(remoteProcHandle, 0, 0, (LPTHREAD_START_ROUTINE)(Process::GetRemoteModuleBaseAddress(foundPid, L"kernel32.dll") + ExitProcessOffset), 0, 0, 0);
-				Logger::logf("UltimateAnticheat.log", Info, "Created remote thread at %llX address", (Process::GetRemoteModuleBaseAddress(foundPid, L"kernel32.dll") + ExitProcessOffset));
+				Logger::logf(Info, "Created remote thread at %llX address", (Process::GetRemoteModuleBaseAddress(foundPid, L"kernel32.dll") + ExitProcessOffset));
 				triedEndDebugger = true;
 			}
 		}

--- a/AntiTamper/Integrity.cpp
+++ b/AntiTamper/Integrity.cpp
@@ -89,7 +89,7 @@ bool Integrity::IsUnknownModulePresent()
 			}
 			else
 			{
-				Logger::logfw("UltimateAnticheat.log", Detection, L"Unsigned module was found loaded in the process: %s", it->name);
+				Logger::logfw(Detection, L"Unsigned module was found loaded in the process: %s", it->name);
 				foundUnknown = true;
 			}
 		}

--- a/AntiTamper/NAuthenticode.cpp
+++ b/AntiTamper/NAuthenticode.cpp
@@ -42,7 +42,7 @@ BOOL Authenticode::VerifyEmbeddedSignature(LPCWSTR filePath)
 
         if (status == CERT_E_REVOKED || status == CERT_E_EXPIRED || status == CERT_E_UNTRUSTEDROOT || status == CERT_E_CHAINING)
         {
-			Logger::log("UltimateAnticheat.log", LogType::Detection, "Revoked or expired signature detected");
+			Logger::log(LogType::Detection, "Revoked or expired signature detected");
 			return FALSE;
 	}
     }
@@ -63,7 +63,7 @@ BOOL Authenticode::VerifyCatalogSignature(LPCWSTR filePath)
     HANDLE hFile = CreateFileW(filePath, GENERIC_READ, FILE_SHARE_READ, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
     if (hFile == INVALID_HANDLE_VALUE) 
     {
-        Logger::logfw("UltimateAnticheat.log", LogType::Warning, L"Could not open file: %s @ VerifyCatalogSignature", filePath);
+        Logger::logfw(LogType::Warning, L"Could not open file: %s @ VerifyCatalogSignature", filePath);
         return false;
     }
 
@@ -90,7 +90,7 @@ BOOL Authenticode::VerifyCatalogSignature(LPCWSTR filePath)
     HCATINFO hCatInfo = CryptCATAdminEnumCatalogFromHash(hCatAdmin, pbHash, cbHash, 0, NULL);
     if (hCatInfo == NULL) 
     {
-        //Logger::logfw("UltimateAnticheat.log", LogType::Warning, L"No catalog file found for: %s @ VerifyCatalogSignature", filePath);
+        //Logger::logfw(LogType::Warning, L"No catalog file found for: %s @ VerifyCatalogSignature", filePath);
         CryptCATAdminReleaseContext(hCatAdmin, 0);
         CloseHandle(hFile);
         return false;
@@ -170,7 +170,7 @@ BOOL Authenticode::GetDateOfTimeStamp(PCMSG_SIGNER_INFO pSignerInfo, SYSTEMTIME*
                 &dwData);
             if (!fResult)
             {
-                Logger::logf("UltimateAnticheat.log", Err, "CryptDecodeObject failed with %x @ Authenticode::GetTimeStampSignerInfo", GetLastError());
+                Logger::logf(Err, "CryptDecodeObject failed with %x @ Authenticode::GetTimeStampSignerInfo", GetLastError());
                 break;
             }
 
@@ -233,7 +233,7 @@ BOOL Authenticode::GetProgAndPublisherInfo(__in PCMSG_SIGNER_INFO pSignerInfo, _
                     &dwData);
                 if (!fResult)
                 {
-                    Logger::logf("UltimateAnticheat.log", Err, "CryptDecodeObject failed with %x @ Authenticode::GetProgAndPublisherInfo", GetLastError());
+                    Logger::logf(Err, "CryptDecodeObject failed with %x @ Authenticode::GetProgAndPublisherInfo", GetLastError());
                     __leave;
                 }
 
@@ -241,7 +241,7 @@ BOOL Authenticode::GetProgAndPublisherInfo(__in PCMSG_SIGNER_INFO pSignerInfo, _
                 OpusInfo = (PSPC_SP_OPUS_INFO)LocalAlloc(LPTR, dwData);
                 if (!OpusInfo)
                 {
-                    Logger::logf("UltimateAnticheat.log", Err, "Unable to allocate memory for publisher info @ Authenticode::GetProgAndPublisherInfo");
+                    Logger::logf(Err, "Unable to allocate memory for publisher info @ Authenticode::GetProgAndPublisherInfo");
                     __leave;
                 }
 
@@ -255,7 +255,7 @@ BOOL Authenticode::GetProgAndPublisherInfo(__in PCMSG_SIGNER_INFO pSignerInfo, _
                     &dwData);
                 if (!fResult)
                 {
-                    Logger::logf("UltimateAnticheat.log", Err, "CryptDecodeObject failed with %x @ Authenticode::GetProgAndPublisherInfo", GetLastError());
+                    Logger::logf(Err, "CryptDecodeObject failed with %x @ Authenticode::GetProgAndPublisherInfo", GetLastError());
                     __leave;
                 }
 
@@ -365,7 +365,7 @@ BOOL Authenticode::GetTimeStampSignerInfo(__in PCMSG_SIGNER_INFO pSignerInfo, __
                     &dwSize);
                 if (!fResult)
                 {
-                    Logger::logf("UltimateAnticheat.log", Err, "CryptDecodeObject failed with %x @ Authenticode::GetTimeStampSignerInfo", GetLastError());
+                    Logger::logf(Err, "CryptDecodeObject failed with %x @ Authenticode::GetTimeStampSignerInfo", GetLastError());
                     __leave;
                 }
 
@@ -373,7 +373,7 @@ BOOL Authenticode::GetTimeStampSignerInfo(__in PCMSG_SIGNER_INFO pSignerInfo, __
                 *pCounterSignerInfo = (PCMSG_SIGNER_INFO)LocalAlloc(LPTR, dwSize);
                 if (!*pCounterSignerInfo)
                 {
-                    Logger::logf("UltimateAnticheat.log", Err, "Unable to allocate memory for timestamp info @ Authenticode::GetTimeStampSignerInfo");
+                    Logger::logf(Err, "Unable to allocate memory for timestamp info @ Authenticode::GetTimeStampSignerInfo");
                     __leave;
                 }
 
@@ -388,7 +388,7 @@ BOOL Authenticode::GetTimeStampSignerInfo(__in PCMSG_SIGNER_INFO pSignerInfo, __
                     &dwSize);
                 if (!fResult)
                 {
-                    Logger::logf("UltimateAnticheat.log", Err, "CryptDecodeObject failed with %x @ Authenticode::GetTimeStampSignerInfo", GetLastError());
+                    Logger::logf(Err, "CryptDecodeObject failed with %x @ Authenticode::GetTimeStampSignerInfo", GetLastError());
                     __leave;
                 }
 
@@ -422,20 +422,20 @@ wstring Authenticode::GetCertificateSubject(__in PCCERT_CONTEXT pCertContext)
     // Get Issuer name size.
     if (!(dwData = CertGetNameString(pCertContext, CERT_NAME_SIMPLE_DISPLAY_TYPE, CERT_NAME_ISSUER_FLAG, NULL, NULL, 0)))
     {
-        Logger::logf("UltimateAnticheat.log", Err, "CertGetNameString failed @ GetCertificateSubject");
+        Logger::logf(Err, "CertGetNameString failed @ GetCertificateSubject");
         goto end;
     }
 
     szName = (LPTSTR)LocalAlloc(LPTR, dwData * sizeof(TCHAR));     // Allocate memory for Issuer name.
     if (!szName) 
     {
-        Logger::logf("UltimateAnticheat.log", Err, "Unable to allocate memory for issuer name @ GetCertificateSubject");
+        Logger::logf(Err, "Unable to allocate memory for issuer name @ GetCertificateSubject");
         goto end;
     }
 
     if (!(CertGetNameString(pCertContext, CERT_NAME_SIMPLE_DISPLAY_TYPE, CERT_NAME_ISSUER_FLAG, NULL, szName, dwData)))    // Get Issuer name.
     {
-        Logger::logf("UltimateAnticheat.log", Err, "CertGetNameString failed @ GetCertificateSubject");
+        Logger::logf(Err, "CertGetNameString failed @ GetCertificateSubject");
         goto end;
     }
 
@@ -444,20 +444,20 @@ wstring Authenticode::GetCertificateSubject(__in PCCERT_CONTEXT pCertContext)
 
     if (!(dwData = CertGetNameString(pCertContext, CERT_NAME_SIMPLE_DISPLAY_TYPE, 0, NULL, NULL, 0)))     // Get Subject name size.
     {
-        Logger::logf("UltimateAnticheat.log", Err, "CertGetNameString failed @ GetCertificateSubject");
+        Logger::logf(Err, "CertGetNameString failed @ GetCertificateSubject");
         goto end;
     }
 
     szName = (LPTSTR)LocalAlloc(LPTR, dwData * sizeof(TCHAR));
     if (!szName)
     {
-        Logger::logf("UltimateAnticheat.log", Err, "Unable to allocate memory for subject name @ GetCertificateSubject");
+        Logger::logf(Err, "Unable to allocate memory for subject name @ GetCertificateSubject");
         goto end;
     }
 
     if (!(CertGetNameString(pCertContext, CERT_NAME_SIMPLE_DISPLAY_TYPE, 0, NULL, szName, dwData)))     // Get subject name
     {
-        Logger::logf("UltimateAnticheat.log", Err, "CertGetNameString failed @ GetCertificateSubject");
+        Logger::logf(Err, "CertGetNameString failed @ GetCertificateSubject");
         goto end;
     }
 
@@ -504,7 +504,7 @@ wstring Authenticode::GetSignerFromFile(const std::wstring& filePath)
         NULL);
     if (!fResult)
     {
-        Logger::logf("UltimateAnticheat.log", Err, "CryptQueryObject failed with %x @ GetSignerFromFile", GetLastError());
+        Logger::logf(Err, "CryptQueryObject failed with %x @ GetSignerFromFile", GetLastError());
         return {};
     }
 
@@ -513,7 +513,7 @@ wstring Authenticode::GetSignerFromFile(const std::wstring& filePath)
 
     if (!fResult)
     {
-        Logger::logf("UltimateAnticheat.log", Err, "CryptMsgGetParam failed with %x @ GetSignerFromFile", GetLastError());
+        Logger::logf(Err, "CryptMsgGetParam failed with %x @ GetSignerFromFile", GetLastError());
         return {};
     }
 
@@ -522,7 +522,7 @@ wstring Authenticode::GetSignerFromFile(const std::wstring& filePath)
 
     if (!pSignerInfo)
     {
-        Logger::logf("UltimateAnticheat.log", Err, "Unable to allocate memory for Signer Info @ GetSignerFromFile");
+        Logger::logf(Err, "Unable to allocate memory for Signer Info @ GetSignerFromFile");
         return {};
     }
 
@@ -531,7 +531,7 @@ wstring Authenticode::GetSignerFromFile(const std::wstring& filePath)
 
     if (!fResult)
     {
-        Logger::logf("UltimateAnticheat.log", Err, "CryptMsgGetParam failed with %x @ GetSignerFromFile", GetLastError());
+        Logger::logf(Err, "CryptMsgGetParam failed with %x @ GetSignerFromFile", GetLastError());
         return {};
     }
 
@@ -571,7 +571,7 @@ wstring Authenticode::GetSignerFromFile(const std::wstring& filePath)
         NULL);
     if (!pCertContext)
     {
-        Logger::logf("UltimateAnticheat.log", Err, "CertFindCertificateInStore failed with %x @ GetSignerFromFile", GetLastError());
+        Logger::logf(Err, "CertFindCertificateInStore failed with %x @ GetSignerFromFile", GetLastError());
         return {};
     }
 
@@ -615,7 +615,7 @@ wstring Authenticode::GetSignerFromFile(const std::wstring& filePath)
     //    }
     //    _tprintf(_T("\n"));
     //}
-    //Logger::log("UltimateAnticheat.log", LogType::Warning, "Failed to query file's digital signature @ GetSignerFromFile");
+    //Logger::log(LogType::Warning, "Failed to query file's digital signature @ GetSignerFromFile");
 
     return SubjectCert;
 }

--- a/AntiTamper/remap.cpp
+++ b/AntiTamper/remap.cpp
@@ -128,12 +128,12 @@ RmpRemapImage(
     REMAP_ROUTINE fpRemapRoutine = NULL;
     BOOL status = TRUE;
 
-    Logger::logf("UltimateAnticheat.log", Info, "Remapping image at 0x%IX\n", ImageBase);
+    Logger::logf(Info, "Remapping image at 0x%IX\n", ImageBase);
 
     pNtHeaders = RtlImageNtHeader((PVOID)ImageBase);
     if (!pNtHeaders)
     {
-        Logger::logf("UltimateAnticheat.log", Err, "RtlImageNtHeader failed. (BaseAddress = 0x%IX)\n",
+        Logger::logf(Err, "RtlImageNtHeader failed. (BaseAddress = 0x%IX)\n",
             ImageBase);
         status = FALSE;
         goto exit;
@@ -142,7 +142,7 @@ RmpRemapImage(
     status = RmppVerifyPeSectionAlignment(pNtHeaders);
     if (!status)
     {
-        Logger::logf("UltimateAnticheat.log",Err ,"RmppVerifyPeSectionAlignment failed.\n");
+        Logger::logf(Err ,"RmppVerifyPeSectionAlignment failed.\n");
         goto exit;
     }
 
@@ -155,7 +155,7 @@ RmpRemapImage(
         PAGE_EXECUTE_READWRITE);
     if (!pRemapRegion)
     {
-        Logger::logf("UltimateAnticheat.log", Err, "VirtualAlloc failed: %u\n", GetLastError());
+        Logger::logf(Err, "VirtualAlloc failed: %u\n", GetLastError());
         status = FALSE;
         goto exit;
     }
@@ -179,7 +179,7 @@ RmpRemapImage(
     status = fpRemapRoutine(pRemapRegion);
     if (!status)
     {
-        Logger::logf("UltimateAnticheat.log", Err,"RmppRemapImageRoutine failed.\n");
+        Logger::logf(Err,"RmppRemapImageRoutine failed.\n");
         goto exit;
     }
 
@@ -189,7 +189,7 @@ RmpRemapImage(
     status = RmppValidateRemappedImageProtection(ImageBase);
     if (!status)
     {
-        Logger::logf("UltimateAnticheat.log", Err, "RmppValidateRemappedImageProtection failed.\n");
+        Logger::logf(Err, "RmppValidateRemappedImageProtection failed.\n");
         goto exit;
     }
 
@@ -198,7 +198,7 @@ exit:
     {
         if (!VirtualFree(pRemapRegion, 0, MEM_RELEASE))
         {
-            Logger::logf("UltimateAnticheat.log", Err, "VirtualFree failed: %u\n", GetLastError());
+            Logger::logf(Err, "VirtualFree failed: %u\n", GetLastError());
         }
     }
 
@@ -245,7 +245,7 @@ RmppVerifyPeSectionAlignment(
             SystemInfo.dwAllocationGranularity);
         if (!status)
         {
-            Logger::logf("UltimateAnticheat.log", Err, "Unexpected section alignment. (SectionBase = 0x%IX)\n",
+            Logger::logf(Err, "Unexpected section alignment. (SectionBase = 0x%IX)\n",
                 SectionBase);
             goto exit;
         }
@@ -259,7 +259,7 @@ RmppVerifyPeSectionAlignment(
         SystemInfo.dwAllocationGranularity);
     if (!status)
     {
-        Logger::logf("UltimateAnticheat.log", Err, "Unexpected section alignment. (SectionBase = 0x%IX)\n",
+        Logger::logf(Err, "Unexpected section alignment. (SectionBase = 0x%IX)\n",
             SectionBase);
         goto exit;
     }
@@ -334,7 +334,7 @@ RmppRemapImageRoutine(
     pNtHeaders = RtlImageNtHeader(pRemapRegion);
     if (!pNtHeaders)
     {
-        Logger::logf("UltimateAnticheat.log", Err, "RtlImageNtHeader failed. (BaseAddress = 0x%IX)\n",
+        Logger::logf(Err, "RtlImageNtHeader failed. (BaseAddress = 0x%IX)\n",
             pRemapRegion);
         status = FALSE;
         goto exit;
@@ -355,7 +355,7 @@ RmppRemapImageRoutine(
         NULL);
     if (!NT_SUCCESS(ntstatus))
     {
-        Logger::logf("UltimateAnticheat.log", Err, "NtCreateSection failed: 0x%X\n", ntstatus);
+        Logger::logf(Err, "NtCreateSection failed: 0x%X\n", ntstatus);
         status = FALSE;
         goto exit;
     }
@@ -376,7 +376,7 @@ RmppRemapImageRoutine(
         PAGE_READWRITE);
     if (!NT_SUCCESS(ntstatus))
     {
-        Logger::logf("UltimateAnticheat.log", Err, "NtMapViewOfSection failed: 0x%X\n", ntstatus);
+        Logger::logf(Err, "NtMapViewOfSection failed: 0x%X\n", ntstatus);
         status = FALSE;
         goto exit;
     }
@@ -392,7 +392,7 @@ RmppRemapImageRoutine(
     ntstatus = NtUnmapViewOfSection(NtCurrentProcess(), pViewBase);
     if (!NT_SUCCESS(ntstatus))
     {
-        Logger::logf("UltimateAnticheat.log", Err, "NtUnmapViewOfSection failed: 0x%X\n", ntstatus);
+        Logger::logf(Err, "NtUnmapViewOfSection failed: 0x%X\n", ntstatus);
         status = FALSE;
         goto exit;
     }
@@ -405,7 +405,7 @@ RmppRemapImageRoutine(
     ntstatus = NtUnmapViewOfSection(NtCurrentProcess(), (PVOID)ImageBase);
     if (!NT_SUCCESS(ntstatus))
     {
-        Logger::logf("UltimateAnticheat.log", Err, "NtUnmapViewOfSection failed: 0x%X\n", ntstatus);
+        Logger::logf(Err, "NtUnmapViewOfSection failed: 0x%X\n", ntstatus);
         status = FALSE;
         goto exit;
     }
@@ -429,7 +429,7 @@ RmppRemapImageRoutine(
             Protection);
         if (!status)
         {
-            Logger::logf("UltimateAnticheat.log", Err, "RmppMapProtectedView failed.\n");
+            Logger::logf(Err, "RmppMapProtectedView failed.\n");
             goto exit;
         }
     }
@@ -445,7 +445,7 @@ RmppRemapImageRoutine(
         PAGE_READONLY);
     if (!status)
     {
-        Logger::logf("UltimateAnticheat.log", Err, "RmppMapProtectedView failed.\n");
+        Logger::logf(Err, "RmppMapProtectedView failed.\n");
         goto exit;
     }
 
@@ -455,7 +455,7 @@ exit:
         ntstatus = NtClose(hSection);
         if (!NT_SUCCESS(ntstatus))
         {
-            Logger::logf("UltimateAnticheat.log", Err, "NtClose failed: 0x%X\n", ntstatus);
+            Logger::logf(Err, "NtClose failed: 0x%X\n", ntstatus);
         }
     }
 
@@ -542,7 +542,7 @@ RmppMapProtectedView(
         Protection);
     if (!NT_SUCCESS(ntstatus))
     {
-        Logger::logf("UltimateAnticheat.log", Err,
+        Logger::logf(Err,
             "NtMapViewOfSection failed: 0x%X (Base = 0x%IX, Offset = 0x%IX, Size = 0x%IX)\n",
             ntstatus,
             pViewBase,
@@ -571,12 +571,12 @@ RmppValidateRemappedImageProtection(
     PIMAGE_SECTION_HEADER pSectionHeader = NULL;
     BOOL status = TRUE;
 
-    Logger::logf("UltimateAnticheat.log", Info, "Validating remapped image protection.\n");
+    Logger::logf(Info, "Validating remapped image protection.\n");
 
     pNtHeaders = RtlImageNtHeader((PVOID)ImageBase);
     if (!pNtHeaders)
     {
-        Logger::logf("UltimateAnticheat.log", Err, "RtlImageNtHeader failed. (BaseAddress = 0x%IX)\n",
+        Logger::logf(Err, "RtlImageNtHeader failed. (BaseAddress = 0x%IX)\n",
             ImageBase);
         status = FALSE;
         goto exit;
@@ -590,7 +590,7 @@ RmppValidateRemappedImageProtection(
             (PVOID)(ImageBase + pSectionHeader[i].VirtualAddress));
         if (!status)
         {
-            Logger::logf("UltimateAnticheat.log", Err, "RmppValidateRemappedPeSectionProtection failed.\n");
+            Logger::logf(Err, "RmppValidateRemappedPeSectionProtection failed.\n");
             goto exit;
         }
     }
@@ -601,7 +601,7 @@ RmppValidateRemappedImageProtection(
     status = RmppValidateRemappedPeSectionProtection((PVOID)ImageBase);
     if (!status)
     {
-        Logger::logf("UltimateAnticheat.log", Err, "RmppValidateRemappedPeSectionProtection failed.\n");
+        Logger::logf(Err, "RmppValidateRemappedPeSectionProtection failed.\n");
         goto exit;
     }
 
@@ -630,7 +630,7 @@ RmppValidateRemappedPeSectionProtection(
     //
     if (!VirtualQuery(pSectionBase, &MemoryBasicInfo, sizeof(MemoryBasicInfo)))
     {
-        Logger::logf("UltimateAnticheat.log", Err, "VirtualQuery failed: %u (BaseAddress = 0x%IX)\n",
+        Logger::logf(Err, "VirtualQuery failed: %u (BaseAddress = 0x%IX)\n",
             GetLastError(),
             pSectionBase);
         status = FALSE;
@@ -662,7 +662,7 @@ RmppValidateRemappedPeSectionProtection(
         &PreviousProtect);
     if (status)
     {
-        Logger::logf("UltimateAnticheat.log", Err,
+        Logger::logf(Err,
             "Section is not protected. (BaseAddress = 0x%IX, Protect = 0x%X)\n",
             pSectionBase,
             PreviousProtect);

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,8 +44,7 @@ file(GLOB_RECURSE RESOURCES
 )
 
 # Explicitly remove CMakeCXXCompilerId.cpp if it's in the list of sources
-list(REMOVE_ITEM SOURCES "${CMAKE_BINARY_DIR}/CMakeCXXCompilerId.cpp")
-list(REMOVE_ITEM SOURCES "${CMAKE_BINARY_DIR}/CMakeFiles/${CMAKE_VERSION}/CompilerIdCXX/CMakeCXXCompilerId.cpp")
+list(FILTER SOURCES EXCLUDE REGEX ".*CMakeCXXCompilerId.cpp$")
 
 # Define the location of the splash.png in the project root
 set(SPLASH_IMAGE "${CMAKE_SOURCE_DIR}/splash.png")

--- a/Common/AntiCheatInitFail.hpp
+++ b/Common/AntiCheatInitFail.hpp
@@ -1,0 +1,40 @@
+#include <string>
+#include <exception>
+#include <map>
+
+enum AntiCheatInitFailReason
+{
+    NullSettings, BadAlloc, DriverNotFound, DriverUnsigned, DriverLoadFail, DispatchFail
+};
+
+class AntiCheatInitFail : public std::exception {
+    public:
+		AntiCheatInitFailReason reasonEnum;
+
+		AntiCheatInitFail(AntiCheatInitFailReason reason) : reasonEnum(reason) {}
+
+		const char * what () const throw() {
+			return reasonExplainMap.at(reasonEnum).c_str();
+		}
+
+	private:
+	#ifdef _DEBUG
+		const std::map<AntiCheatInitFailReason, const std::string> reasonExplainMap = {
+			{ NullSettings, "Settings pointer was NULL" },
+			{ BadAlloc, "Critical allocation failure" },
+			{ DriverNotFound, "Could not  get absolute path from driver relative path" },
+			{ DriverUnsigned, "Driver certificate subject/signer was not correct" },
+			{ DriverLoadFail, "Could not load driver" },
+			{ DispatchFail, "API::Dispatch failed" }
+		};
+	#else
+	const std::map<AntiCheatInitFailReason, const std::string> reasonExplainMap = {
+			{ NullSettings, "" },
+			{ BadAlloc, "" },
+			{ DriverNotFound, "" },
+			{ DriverUnsigned, "" },
+			{ DriverLoadFail, "" },
+			{ DispatchFail, "" }
+		};
+	#endif
+};

--- a/Common/Logger.cpp
+++ b/Common/Logger.cpp
@@ -2,4 +2,5 @@
 #include "Logger.hpp"
 
 bool Logger::enableLogging = true;
-std::mutex Logger::consoleMutex; 
+std::string Logger::logFileName = "";
+std::mutex Logger::consoleMutex;

--- a/Common/Logger.cpp
+++ b/Common/Logger.cpp
@@ -1,5 +1,5 @@
 //AlSch092 @ Github
 #include "Logger.hpp"
 
-bool Logger::logToFile = true;
+bool Logger::enableLogging = true;
 std::mutex Logger::consoleMutex; 

--- a/Common/Logger.hpp
+++ b/Common/Logger.hpp
@@ -27,11 +27,11 @@ const WORD ConsoleTextColors[] =
 class Logger final
 {
 public:
-    static bool logToFile;
+    static bool enableLogging;
 
     static void log(const std::string& filename, LogType type, const std::string& message)
     {
-        if (!logToFile) {
+        if (!enableLogging) {
             return;
         }
         std::lock_guard<std::mutex> lock(consoleMutex);
@@ -108,7 +108,7 @@ public:
 
     static void logw(const std::string& filename, LogType type, const std::wstring& message)
     {
-        if (!logToFile) {
+        if (!enableLogging) {
             return;
         }
         std::wofstream logFile(filename, std::ios::out | std::ios::app);

--- a/Common/Logger.hpp
+++ b/Common/Logger.hpp
@@ -7,6 +7,7 @@
 #include <cstdarg>
 #include <windows.h>
 #include <mutex>
+#include <map>
 
 enum LogType
 {
@@ -27,120 +28,81 @@ const WORD ConsoleTextColors[] =
 class Logger final
 {
 public:
+    static std::string logFileName;
     static bool enableLogging;
 
-    static void log(const std::string& filename, LogType type, const std::string& message)
+    static int getLogColor(LogType type) {
+        const std::map<LogType, int> logColors = {
+            { LogType::Detection,  ConsoleTextColors[0]},
+            { LogType::Info, ConsoleTextColors[3] },
+            { LogType::Err, ConsoleTextColors[5] },
+            { LogType::Warning, FOREGROUND_GREEN }
+        };
+        return logColors.at(type);
+    }
+
+    static void logToFile(std::string& message) {
+        if (logFileName.empty()) {
+            return;
+        }
+        std::ofstream logFile(logFileName, std::ios::out | std::ios::app);
+        if (!logFile.is_open())
+        {
+            std::cerr << "Error: Could not open log file: " << logFileName << std::endl;
+            return;
+        }
+
+        std::time_t now = std::time(nullptr);
+        char timestamp[20];
+        std::strftime(timestamp, sizeof(timestamp), "%Y-%m-%d %H:%M:%S", std::localtime(&now));
+
+        logFile << L"[" << timestamp << L"] " << message << std::endl;
+
+        if (logFile.fail())
+        {
+            std::cerr << "[ERROR] Failed to write to log file: " << logFileName << std::endl;
+            return;
+        }
+
+        logFile.close(); // Close the file after writing
+    }
+
+    static void log(LogType type, const std::string& message)
     {
         if (!enableLogging) {
             return;
         }
         std::lock_guard<std::mutex> lock(consoleMutex);
 
-        std::ofstream logFile(filename, std::ios::out | std::ios::app); //this can throw an exception if the program shuts down during this call 
-
-        if (!logFile.is_open())
-        {
-            std::cerr << "Error: Could not open log file: " << filename << std::endl;
-            return;
-        }
-
         std::string msg_with_errorcode;
-        switch (type)
-        {
-        case Err:
-            msg_with_errorcode = "[ERROR] ";
-            break;
-        case Detection:
-            msg_with_errorcode = "[DETECTION] ";
-            break;
-        case Info:
-            msg_with_errorcode = "[INFO] ";
-            break;
-        case Warning:
-            msg_with_errorcode = "[WARNING] ";
-            break;
-        default:
-            msg_with_errorcode = "[ERROR] ";
-            break;
-        }
+
+        const std::map<LogType, const std::string> msgsTypes = {
+            { LogType::Detection,  "[DETECTION] "},
+            { LogType::Info, "[INFO] " },
+            { LogType::Err, "[ERROR] " },
+            { LogType::Warning, "[WARNING] " }
+        };
+
+        msg_with_errorcode = msgsTypes.at(type);
         msg_with_errorcode += message;
 
-        std::time_t now = std::time(nullptr);
-        char timestamp[20];
-        std::strftime(timestamp, sizeof(timestamp), "%Y-%m-%d %H:%M:%S", std::localtime(&now));
+        logToFile(msg_with_errorcode);
 
-        logFile << "[" << timestamp << "] " << msg_with_errorcode << std::endl;
-
-        if (type == Detection)
-        {
-            SetColor(ConsoleTextColors[0]);
-            printf("%s\n", msg_with_errorcode.c_str());
-            ResetColor();
-        }
-        else if (type == Info)
-        {
-            SetColor(ConsoleTextColors[3]);
-            printf("%s\n", msg_with_errorcode.c_str());
-            ResetColor();
-        }
-        else if (type == Warning)
-        {
-            SetColor(FOREGROUND_GREEN);
-            printf("%s\n", msg_with_errorcode.c_str());
-            ResetColor();
-        }
-        else if (type == Err)
-        {
-            SetColor(ConsoleTextColors[5]);
-            printf("%s\n", msg_with_errorcode.c_str());
-            ResetColor();
-        }
-        else
-            printf("%s\n", msg_with_errorcode.c_str());
-
-        if (logFile.fail())
-        {
-            std::cerr << "[ERROR] Failed to write to log file: " << filename << std::endl;
-        }
-
-        logFile.close();
+        SetColor(getLogColor(type));
+        printf("%s\n", msg_with_errorcode.c_str());
+        ResetColor();
     }
 
-    static void logw(const std::string& filename, LogType type, const std::wstring& message)
-    {
-        if (!enableLogging) {
+    static void logToWFile(std::wstring& message) {
+        if (logFileName.empty()) {
             return;
         }
-        std::wofstream logFile(filename, std::ios::out | std::ios::app);
-
+        std::wofstream logFile(logFileName, std::ios::out | std::ios::app);
         if (!logFile.is_open())
         {
-            std::cerr << "Error: Could not open log file: " << filename << std::endl;
+            std::cerr << "Error: Could not open log file: " << logFileName << std::endl;
             return;
         }
-
-        std::wstring msg_with_errorcode;
-
-        switch (type)
-        {
-        case Err:
-            msg_with_errorcode = L"[ERROR] ";
-            break;
-        case Detection:
-            msg_with_errorcode = L"[DETECTION] ";
-            break;
-        case Info:
-            msg_with_errorcode = L"[INFO] ";
-            break;
-        case Warning:
-            msg_with_errorcode = L"[WARNING] ";
-            break;
-        default:
-            msg_with_errorcode = L"[ERROR] ";
-            break;
-        }
-
-        msg_with_errorcode += message;
 
         std::time_t now = std::time(nullptr);
         std::tm localtime;
@@ -148,48 +110,46 @@ public:
         wchar_t timestamp[256] = { 0 };
         std::wcsftime(timestamp, 256, L"%Y-%m-%d %H:%M:%S", &localtime);
 
-        logFile << L"[" << timestamp << L"] " << msg_with_errorcode << std::endl;
-
-        if (type == Detection)
-        {
-            SetColor(ConsoleTextColors[0]);
-            wprintf(L"%s\n", msg_with_errorcode.c_str());
-            ResetColor();
-        }
-        else if (type == Info)
-        {
-            SetColor(ConsoleTextColors[3]);
-            wprintf(L"%s\n", msg_with_errorcode.c_str());
-            ResetColor();
-        }
-        else if (type == Warning)
-        {
-            SetColor(FOREGROUND_GREEN);
-            wprintf(L"%s\n", msg_with_errorcode.c_str());
-            ResetColor();
-        }
-        else if (type == Err)
-        {
-            SetColor(ConsoleTextColors[5]);
-            wprintf(L"%s\n", msg_with_errorcode.c_str());
-            ResetColor();
-        }
-        else
-            wprintf(L"%s\n", msg_with_errorcode.c_str());
+        logFile << L"[" << timestamp << L"] " << message << std::endl;
 
         if (logFile.fail())
         {
-            std::cerr << "[ERROR] Failed to write to log file: " << filename << std::endl;
+            std::cerr << "[ERROR] Failed to write to log file: " << logFileName << std::endl;
             return;
         }
 
         logFile.close(); // Close the file after writing
     }
 
-    template<typename... Args>
-    static void logf(const char* filename, LogType type, const char* format, Args... args)
+
+    static void logw(LogType type, const std::wstring& message)
     {
-        if (format == NULL || filename == NULL)
+        if (!enableLogging) {
+            return;
+        }
+
+        std::wstring msg_with_errorcode;
+
+        const std::map<LogType, const std::wstring> msgsTypes = {
+            { LogType::Detection,  L"[DETECTION] "},
+            { LogType::Info, L"[INFO] " },
+            { LogType::Err, L"[ERROR] " },
+            { LogType::Warning, L"[WARNING] " }
+        };
+
+        msg_with_errorcode = msgsTypes.at(type);
+        msg_with_errorcode += message;
+        logToWFile(msg_with_errorcode);
+
+        SetColor(getLogColor(type));
+        wprintf(L"%s\n", msg_with_errorcode.c_str());
+        ResetColor();
+    }
+
+    template<typename... Args>
+    static void logf(LogType type, const char* format, Args... args)
+    {
+        if (format == NULL)
             return;
 
         const int buffSize = 1024;
@@ -198,7 +158,7 @@ public:
         int ret = std::snprintf(buffer, buffSize, format, args...);
         if (ret >= 0 && ret < buffSize)
         {
-            log(filename, type, std::string(buffer));
+            log(type, std::string(buffer));
         }
         else 
         {
@@ -207,9 +167,9 @@ public:
     }
 
     template<typename... Args>
-    static void logfw(const char* filename, LogType type, const wchar_t* format, Args... args)
+    static void logfw(LogType type, const wchar_t* format, Args... args)
     {
-        if (format == NULL || filename == NULL)
+        if (format == NULL)
             return;
 
         const int buffSize = 1024;
@@ -218,7 +178,7 @@ public:
         int ret = _snwprintf(buffer, buffSize, format, args...);
         if (ret >= 0 && ret < buffSize)
         {
-            logw(filename, type, std::wstring(buffer));
+            logw(type, std::wstring(buffer));
         }
         else
         {
@@ -240,7 +200,7 @@ public:
     template<typename... Args>
     static bool LogErrorAndReturn(const char* format, Args... args)
     {
-		logf("UltimateAnticheat.log", Err, format, args...);
+		logf(Err, format, args...);
         return false;
     }
 

--- a/Common/Settings.hpp
+++ b/Common/Settings.hpp
@@ -20,7 +20,8 @@ public:
 		bool bRequireRunAsAdministrator,
 		bool bUsingDriver,
 		const std::list<std::wstring> allowedParents,
-		bool enableLogging)
+		bool enableLogging,
+		const std::string logFileName)
 	{
 		if (!Instance)
 		{
@@ -36,7 +37,8 @@ public:
 				bRequireRunAsAdministrator,
 				bUsingDriver,
 				allowedParents,
-				enableLogging));
+				enableLogging,
+				logFileName));
 		}
 
 		return Instance;
@@ -58,6 +60,7 @@ public:
 	bool bUsingDriver; //signed kernelmode driver for hybrid approach
 	const std::list<std::wstring> allowedParents;
 	bool enableLogging;
+	const std::string logFileName;
 
 	wstring GetKMDriverName() const { return this->KMDriverName; }
 	wstring GetKMDriverPath() const { return this->KMDriverPath; }
@@ -76,10 +79,12 @@ private:
 		bool bRequireRunAsAdministrator,
 		bool bUsingDriver,
 		const std::list<std::wstring> allowedParents,
-		bool enableLogging)
-		: bNetworkingEnabled(bNetworkingEnabled), bEnforceSecureBoot(bEnforceSecureBoot), bEnforceDSE(bEnforceDSE), bEnforceNoKDbg(bEnforceNoKDbg), bUseAntiDebugging(bUseAntiDebugging), bCheckIntegrity(bCheckIntegrity), bCheckThreads(bCheckThreads), bCheckHypervisor(bCheckHypervisor), bRequireRunAsAdministrator(bRequireRunAsAdministrator), bUsingDriver(bUsingDriver), allowedParents(allowedParents), enableLogging(enableLogging)
+		bool enableLogging,
+		const std::string logFileName)
+		: bNetworkingEnabled(bNetworkingEnabled), bEnforceSecureBoot(bEnforceSecureBoot), bEnforceDSE(bEnforceDSE), bEnforceNoKDbg(bEnforceNoKDbg), bUseAntiDebugging(bUseAntiDebugging), bCheckIntegrity(bCheckIntegrity), bCheckThreads(bCheckThreads), bCheckHypervisor(bCheckHypervisor), bRequireRunAsAdministrator(bRequireRunAsAdministrator), bUsingDriver(bUsingDriver), allowedParents(allowedParents), enableLogging(enableLogging), logFileName(logFileName)
 	{
 		Logger::enableLogging = enableLogging; //put this line here to be as early as possible.
+		Logger::logFileName = logFileName;
 	}
 	 
 	const wstring KMDriverName = L"UltimateKernelAnticheat"; //optional hybrid approach

--- a/Common/Settings.hpp
+++ b/Common/Settings.hpp
@@ -20,7 +20,7 @@ public:
 		bool bRequireRunAsAdministrator,
 		bool bUsingDriver,
 		const std::list<std::wstring> allowedParents,
-		bool logToFile)
+		bool enableLogging)
 	{
 		if (!Instance)
 		{
@@ -36,7 +36,7 @@ public:
 				bRequireRunAsAdministrator,
 				bUsingDriver,
 				allowedParents,
-				logToFile));
+				enableLogging));
 		}
 
 		return Instance;
@@ -57,7 +57,7 @@ public:
 	bool bNetworkingEnabled; //previously in API.hpp
 	bool bUsingDriver; //signed kernelmode driver for hybrid approach
 	const std::list<std::wstring> allowedParents;
-	bool logToFile;
+	bool enableLogging;
 
 	wstring GetKMDriverName() const { return this->KMDriverName; }
 	wstring GetKMDriverPath() const { return this->KMDriverPath; }
@@ -76,10 +76,10 @@ private:
 		bool bRequireRunAsAdministrator,
 		bool bUsingDriver,
 		const std::list<std::wstring> allowedParents,
-		bool logToFile)
-		: bNetworkingEnabled(bNetworkingEnabled), bEnforceSecureBoot(bEnforceSecureBoot), bEnforceDSE(bEnforceDSE), bEnforceNoKDbg(bEnforceNoKDbg), bUseAntiDebugging(bUseAntiDebugging), bCheckIntegrity(bCheckIntegrity), bCheckThreads(bCheckThreads), bCheckHypervisor(bCheckHypervisor), bRequireRunAsAdministrator(bRequireRunAsAdministrator), bUsingDriver(bUsingDriver), allowedParents(allowedParents), logToFile(logToFile)
+		bool enableLogging)
+		: bNetworkingEnabled(bNetworkingEnabled), bEnforceSecureBoot(bEnforceSecureBoot), bEnforceDSE(bEnforceDSE), bEnforceNoKDbg(bEnforceNoKDbg), bUseAntiDebugging(bUseAntiDebugging), bCheckIntegrity(bCheckIntegrity), bCheckThreads(bCheckThreads), bCheckHypervisor(bCheckHypervisor), bRequireRunAsAdministrator(bRequireRunAsAdministrator), bUsingDriver(bUsingDriver), allowedParents(allowedParents), enableLogging(enableLogging)
 	{
-		Logger::logToFile = logToFile; //put this line here to be as early as possible.
+		Logger::enableLogging = enableLogging; //put this line here to be as early as possible.
 	}
 	 
 	const wstring KMDriverName = L"UltimateKernelAnticheat"; //optional hybrid approach

--- a/Detections.hpp
+++ b/Detections.hpp
@@ -46,13 +46,13 @@ public:
 		}
 		catch (const std::bad_alloc& e) 
 		{
-			Logger::logf("UltimateAnticheat.log", Err, "One or more pointers could not be allocated @ Detections::Detections: %s", e.what());
+			Logger::logf(Err, "One or more pointers could not be allocated @ Detections::Detections: %s", e.what());
 			std::terminate();
 		}
 	
 		if (!FetchBlacklistedBytePatterns(BlacklisteBytePatternRepository))
 		{
-			Logger::logf("UltimateAnticheat.log", Warning, "Failed to fetch blacklisted byte patterns from web location!");
+			Logger::logf(Warning, "Failed to fetch blacklisted byte patterns from web location!");
 		}
 
 		this->CheaterWasDetected = new ObfuscatedData<uint8_t>((bool)false);

--- a/Environment/Services.cpp
+++ b/Environment/Services.cpp
@@ -55,7 +55,7 @@ BOOL Services::GetServiceModules()
 
     if (scmHandle == NULL) 
     {
-        Logger::logf("UltimateAnticheat.log", Err, "Failed to open Service Control Manager @ GetServiceModules: %lu\n", GetLastError());
+        Logger::logf(Err, "Failed to open Service Control Manager @ GetServiceModules: %lu\n", GetLastError());
         return FALSE;
     }
 
@@ -63,7 +63,7 @@ BOOL Services::GetServiceModules()
 
     if (!result && GetLastError() != ERROR_MORE_DATA) 
     {
-        Logger::logf("UltimateAnticheat.log", Err, "Failed to enumerate services @ GetServiceModules: %lu\n", GetLastError());
+        Logger::logf(Err, "Failed to enumerate services @ GetServiceModules: %lu\n", GetLastError());
         CloseServiceHandle(scmHandle);
         return FALSE;
     }
@@ -72,7 +72,7 @@ BOOL Services::GetServiceModules()
     
     if (services == NULL) 
     {
-        Logger::logf("UltimateAnticheat.log", Err, "Memory allocation failed @ GetServiceModules");
+        Logger::logf(Err, "Memory allocation failed @ GetServiceModules");
         CloseServiceHandle(scmHandle);
         return FALSE;
     }
@@ -81,7 +81,7 @@ BOOL Services::GetServiceModules()
 
     if (!result) 
     {
-        Logger::logf("UltimateAnticheat.log", Err, "Failed to enumerate services @ GetServiceModules: %lu\n", GetLastError());
+        Logger::logf(Err, "Failed to enumerate services @ GetServiceModules: %lu\n", GetLastError());
         free(services);
         CloseServiceHandle(scmHandle);
         return FALSE;
@@ -130,7 +130,7 @@ BOOL Services::GetLoadedDrivers()
 
     if (!EnumDeviceDrivers((LPVOID*)drivers, sizeof(drivers), &cbNeeded)) 
     {
-        Logger::logf("UltimateAnticheat.log", Err, "Failed to enumerate device drivers @ GetLoadedDrivers");
+        Logger::logf(Err, "Failed to enumerate device drivers @ GetLoadedDrivers");
         return FALSE;
     }
 
@@ -149,14 +149,14 @@ BOOL Services::GetLoadedDrivers()
             {
                 if (Utility::ContainsWStringInsensitive(driverPath, blacklisted))
                 {
-                    Logger::logfw("UltimateAnticheat.log", Detection, L"Found Vulnerable loaded driver @ GetLoadedDrivers: %s", driverPath);
+                    Logger::logfw(Detection, L"Found Vulnerable loaded driver @ GetLoadedDrivers: %s", driverPath);
                     this->FoundBlacklistedDrivers.push_back(driverPath);
                 }
             }
         }
         else 
         {
-            Logger::logf("UltimateAnticheat.log", Err, "Failed to get driver information @ GetLoadedDrivers : error %d\n", GetLastError());
+            Logger::logf(Err, "Failed to get driver information @ GetLoadedDrivers : error %d\n", GetLastError());
             return FALSE;
         }
     }
@@ -175,7 +175,7 @@ list<wstring> Services::GetUnsignedDrivers()
     {
         if (!GetLoadedDrivers())
         {
-            Logger::logf("UltimateAnticheat.log", Err, "Failed to get driver list @ GetUnsignedDrivers : error %d\n", GetLastError());
+            Logger::logf(Err, "Failed to get driver list @ GetUnsignedDrivers : error %d\n", GetLastError());
             return unsignedDrivers;
         }
     }
@@ -207,12 +207,12 @@ list<wstring> Services::GetUnsignedDrivers()
 
         if (!foundWhitelisted && !Authenticode::HasSignature(fixedDriverPath.c_str()))
         {
-            Logger::logfw("UltimateAnticheat.log", Warning, L"Found unsigned or outdated certificate on driver: %s\n", fixedDriverPath.c_str());
+            Logger::logfw(Warning, L"Found unsigned or outdated certificate on driver: %s\n", fixedDriverPath.c_str());
             unsignedDrivers.push_back(fixedDriverPath);
         }
         //else
         //{
-        //    Logger::logfw("UltimateAnticheat.log", Info, L"Driver is signed: %s\n", fixedDriverPath.c_str()); //commented out to prevent flooding the console
+        //    Logger::logfw(Info, L"Driver is signed: %s\n", fixedDriverPath.c_str()); //commented out to prevent flooding the console
         //}
     }
 
@@ -241,7 +241,7 @@ BOOL Services::IsTestsigningEnabled()
 
     if (!CreatePipe(&hReadPipe, &hWritePipe, &sa, 0)) //use a pipe to read output of bcdedit command
     {
-        Logger::logf("UltimateAnticheat.log", Err, "CreatePipe failed @ Services::IsMachineAllowingSelfSignedDrivers: %d\n", GetLastError());
+        Logger::logf(Err, "CreatePipe failed @ Services::IsMachineAllowingSelfSignedDrivers: %d\n", GetLastError());
         return foundTestsigning;
     }
 
@@ -255,7 +255,7 @@ BOOL Services::IsTestsigningEnabled()
 
     if (!CreateProcessA(fullpath_bcdedit.c_str(), NULL, NULL, NULL, TRUE, CREATE_NO_WINDOW, NULL, NULL, &si, &pi))
     {
-        Logger::logf("UltimateAnticheat.log", Err, "CreateProcess failed @ Services::IsMachineAllowingSelfSignedDrivers: %d\n", GetLastError());
+        Logger::logf(Err, "CreateProcess failed @ Services::IsMachineAllowingSelfSignedDrivers: %d\n", GetLastError());
         CloseHandle(hReadPipe);
         CloseHandle(hWritePipe);
         return FALSE;
@@ -269,7 +269,7 @@ BOOL Services::IsTestsigningEnabled()
 
     if (!ReadFile(hReadPipe, szOutput, 1024 - 1, &bytesRead, NULL)) //now read our pipe
     {
-        Logger::logf("UltimateAnticheat.log", Err, "ReadFile failed @ Services::IsMachineAllowingSelfSignedDrivers: %d\n", GetLastError());
+        Logger::logf(Err, "ReadFile failed @ Services::IsMachineAllowingSelfSignedDrivers: %d\n", GetLastError());
         CloseHandle(hReadPipe);
         return FALSE;
     }
@@ -280,7 +280,7 @@ BOOL Services::IsTestsigningEnabled()
 
     if (strstr(szOutput, "The boot configuration data store could not be opened") != NULL)
     {
-        Logger::logf("UltimateAnticheat.log", Err, "Failed to run bcdedit @ IsMachineAllowingSelfSignedDrivers. Please make sure program is run as administrator\n");
+        Logger::logf(Err, "Failed to run bcdedit @ IsMachineAllowingSelfSignedDrivers. Please make sure program is run as administrator\n");
         foundTestsigning = FALSE;
     }
 
@@ -322,7 +322,7 @@ BOOL Services::IsDebugModeEnabled()
 
     if (!CreatePipe(&hReadPipe, &hWritePipe, &sa, 0)) //use a pipe to read output of bcdedit command
     {
-        Logger::logf("UltimateAnticheat.log", Err, "CreatePipe failed @ Services::IsMachineAllowingSelfSignedDrivers: %d\n", GetLastError());
+        Logger::logf(Err, "CreatePipe failed @ Services::IsMachineAllowingSelfSignedDrivers: %d\n", GetLastError());
         return foundKDebugMode;
     }
 
@@ -336,7 +336,7 @@ BOOL Services::IsDebugModeEnabled()
 
     if (!CreateProcessA(fullpath_bcdedit.c_str(), NULL, NULL, NULL, TRUE, CREATE_NO_WINDOW, NULL, NULL, &si, &pi))
     {
-        Logger::logf("UltimateAnticheat.log", Err, "CreateProcess failed @ Services::IsDebugModeEnabled: %d\n", GetLastError());
+        Logger::logf(Err, "CreateProcess failed @ Services::IsDebugModeEnabled: %d\n", GetLastError());
         CloseHandle(hReadPipe);
         CloseHandle(hWritePipe);
         return foundKDebugMode;
@@ -350,7 +350,7 @@ BOOL Services::IsDebugModeEnabled()
 
     if (!ReadFile(hReadPipe, szOutput, 1024 - 1, &bytesRead, NULL)) //now read our pipe
     {
-        Logger::logf("UltimateAnticheat.log", Err, "ReadFile failed @ Services::IsDebugModeEnabled: %d\n", GetLastError());
+        Logger::logf(Err, "ReadFile failed @ Services::IsDebugModeEnabled: %d\n", GetLastError());
         CloseHandle(hReadPipe);
         return foundKDebugMode;
     }
@@ -361,7 +361,7 @@ BOOL Services::IsDebugModeEnabled()
 
     if (strstr(szOutput, "The boot configuration data store could not be opened") != NULL)
     {
-        Logger::logf("UltimateAnticheat.log", Err, "Failed to run bcdedit @ IsMachineAllowingSelfSignedDrivers. Please make sure program is run as administrator\n");
+        Logger::logf(Err, "Failed to run bcdedit @ IsMachineAllowingSelfSignedDrivers. Please make sure program is run as administrator\n");
         foundKDebugMode = FALSE;
     }
 
@@ -399,7 +399,7 @@ BOOL Services::IsSecureBootEnabled()
 
     if (!CreatePipe(&hReadPipe, &hWritePipe, &sa, 0)) //use a pipe to read output of bcdedit command
     {
-        Logger::logf("UltimateAnticheat.log", Err, "CreatePipe failed @ Services::IsSecureBootEnabled: %d\n", GetLastError());
+        Logger::logf(Err, "CreatePipe failed @ Services::IsSecureBootEnabled: %d\n", GetLastError());
         return FALSE;
     }
 
@@ -410,7 +410,7 @@ BOOL Services::IsSecureBootEnabled()
 
     if (!CreateProcessA(NULL, (LPSTR)"powershell -c \"Confirm-SecureBootUEFI\"", NULL, NULL, TRUE, CREATE_NO_WINDOW, NULL, NULL, &si, &pi))
     {
-        Logger::logf("UltimateAnticheat.log", Err, "CreateProcess failed @ Services::IsSecureBootEnabled: %d\n", GetLastError());
+        Logger::logf(Err, "CreateProcess failed @ Services::IsSecureBootEnabled: %d\n", GetLastError());
         CloseHandle(hReadPipe);
         CloseHandle(hWritePipe);
         return FALSE;
@@ -424,7 +424,7 @@ BOOL Services::IsSecureBootEnabled()
 
     if (!ReadFile(hReadPipe, szOutput, 1024 - 1, &bytesRead, NULL)) //now read our pipe
     {
-        Logger::logf("UltimateAnticheat.log", Err, "ReadFile failed @ Services::IsSecureBootEnabled: %d\n", GetLastError());
+        Logger::logf(Err, "ReadFile failed @ Services::IsSecureBootEnabled: %d\n", GetLastError());
         CloseHandle(hReadPipe);
         return FALSE;
     }
@@ -435,7 +435,7 @@ BOOL Services::IsSecureBootEnabled()
 
     if (strstr(szOutput, "Cmdlet not supported on this platform") != NULL) //
     {
-        Logger::logf("UltimateAnticheat.log", Err, "Failed to run bcdedit @ IsMachineAllowingSelfSignedDrivers. Please make sure program is run as administrator\n");
+        Logger::logf(Err, "Failed to run bcdedit @ IsMachineAllowingSelfSignedDrivers. Please make sure program is run as administrator\n");
         secureBootEnabled = FALSE;
     }
 
@@ -462,14 +462,14 @@ string Services::GetWindowsDrive()
     charCount = GetWindowsDirectoryA(volumePath, MAX_PATH);
     if (charCount == 0)
     {
-        Logger::logf("UltimateAnticheat.log", Err, "Failed to retrieve Windows directory path @ Services::GetWindowsPath: %d\n", GetLastError());
+        Logger::logf(Err, "Failed to retrieve Windows directory path @ Services::GetWindowsPath: %d\n", GetLastError());
         return "";
     }
 
     CHAR volumeName[MAX_PATH];
     if (!GetVolumePathNameA(volumePath, volumeName, MAX_PATH))
     {
-        Logger::logf("UltimateAnticheat.log", Err, "Failed to retrieve volume path name @ Services::GetWindowsPath: %d\n", GetLastError());
+        Logger::logf(Err, "Failed to retrieve volume path name @ Services::GetWindowsPath: %d\n", GetLastError());
         return "";
     }
 
@@ -487,14 +487,14 @@ wstring Services::GetWindowsDriveW()
     charCount = GetWindowsDirectoryW(volumePath, MAX_PATH);
     if (charCount == 0)
     {
-        Logger::logf("UltimateAnticheat.log", Err, "Failed to retrieve Windows directory path @ Services::GetWindowsPathW: %d\n", GetLastError());
+        Logger::logf(Err, "Failed to retrieve Windows directory path @ Services::GetWindowsPathW: %d\n", GetLastError());
         return L"";
     }
 
     wchar_t volumeName[MAX_PATH];
     if (!GetVolumePathNameW(volumePath, volumeName, MAX_PATH))
     {
-        Logger::logf("UltimateAnticheat.log", Err, "Failed to retrieve volume path name @ Services::GetWindowsPathW: %d\n", GetLastError());
+        Logger::logf(Err, "Failed to retrieve volume path name @ Services::GetWindowsPathW: %d\n", GetLastError());
         return L"";
     }
 
@@ -533,7 +533,7 @@ list<DeviceW> Services::GetHardwareDevicesW()
 
     if (deviceInfoSet == INVALID_HANDLE_VALUE) 
     {
-        Logger::logf("UltimateAnticheat.log", Warning, "SetupDiGetClassDevs failed with error: %d @ Services::GetHardwareDevicesW\n", GetLastError());
+        Logger::logf(Warning, "SetupDiGetClassDevs failed with error: %d @ Services::GetHardwareDevicesW\n", GetLastError());
         return {};
     }
 
@@ -564,13 +564,13 @@ list<DeviceW> Services::GetHardwareDevicesW()
             continue;
         }
 
-        Logger::logfw("UltimateAnticheat.log", Info, L"Found Device: %s\n", d.Description.c_str());
+        Logger::logfw(Info, L"Found Device: %s\n", d.Description.c_str());
         deviceList.push_back(d);
     }
 
     if (GetLastError() != ERROR_NO_MORE_ITEMS)
     {
-        Logger::logf("UltimateAnticheat.log", Warning, "SetupDiEnumDeviceInfo failed with error: %d @ Services::GetHardwareDevicesW\n", GetLastError());
+        Logger::logf(Warning, "SetupDiEnumDeviceInfo failed with error: %d @ Services::GetHardwareDevicesW\n", GetLastError());
     }
 
     SetupDiDestroyDeviceInfoList(deviceInfoSet); 
@@ -601,7 +601,7 @@ BOOL Services::IsSecureBootEnabled_RegKey()
 
     if (lResult != ERROR_SUCCESS) 
     {
-        Logger::logf("UltimateAnticheat.log", Warning, "RegCloseKey failed with error: %d @ Services::IsSecureBootEnabled_RegKey\n", lResult);
+        Logger::logf(Warning, "RegCloseKey failed with error: %d @ Services::IsSecureBootEnabled_RegKey\n", lResult);
         RegCloseKey(hKey);
         return FALSE;
     }
@@ -635,7 +635,7 @@ BOOL Services::CheckUSBDevices()
 
     if (deviceInfoSet == INVALID_HANDLE_VALUE) 
     {
-        //Logger::log("UltimateAnticheat.log", Err, "Failed to get device information set.");
+        //Logger::log(Err, "Failed to get device information set.");
         return FALSE;
     }
 
@@ -679,7 +679,7 @@ WindowsVersion Services::GetWindowsVersion()
 
     if (status != 0)
     {
-        Logger::logf("UltimateAnticheat.log", Warning, "Services::GetWindowsMajorVersion failed with error: %x", status);
+        Logger::logf(Warning, "Services::GetWindowsMajorVersion failed with error: %x", status);
         return ErrorUnknown;
     }
 
@@ -789,7 +789,7 @@ bool Services::LoadDriver(const std::wstring& driverName, const std::wstring& dr
 
     if (!hSCManager)
     {
-        Logger::logfw("UltimateAnticheat.log", Warning, L"Failed to open SCM: %d", GetLastError());
+        Logger::logfw(Warning, L"Failed to open SCM: %d", GetLastError());
         return false;
     }
 
@@ -812,7 +812,7 @@ bool Services::LoadDriver(const std::wstring& driverName, const std::wstring& dr
         }
         else
         {
-            Logger::logfw("UltimateAnticheat.log", Warning, L"Failed to create service:  %d", GetLastError());
+            Logger::logfw(Warning, L"Failed to create service:  %d", GetLastError());
             CloseServiceHandle(hSCManager);
             return false;
         }
@@ -822,13 +822,13 @@ bool Services::LoadDriver(const std::wstring& driverName, const std::wstring& dr
     {
         if (GetLastError() != ERROR_SERVICE_ALREADY_RUNNING)
         {
-            Logger::logfw("UltimateAnticheat.log", Warning, L"Failed to start service: %d", GetLastError());
+            Logger::logfw(Warning, L"Failed to start service: %d", GetLastError());
             loadSuccess = false;
         }
     }
 
     if(loadSuccess)
-        Logger::logfw("UltimateAnticheat.log", Info, L"Driver %s loaded successfully.", driverName.c_str());
+        Logger::logfw(Info, L"Driver %s loaded successfully.", driverName.c_str());
 
     CloseServiceHandle(hService);
     CloseServiceHandle(hSCManager);
@@ -847,7 +847,7 @@ bool Services::UnloadDriver(const std::wstring& driverName)
 
     if (!hSCManager)
     {
-        Logger::logfw("UltimateAnticheat.log", Warning, L"Failed to open SCM: %d", GetLastError());
+        Logger::logfw(Warning, L"Failed to open SCM: %d", GetLastError());
         return false;
     }
 
@@ -855,7 +855,7 @@ bool Services::UnloadDriver(const std::wstring& driverName)
 
     if (!hService)
     {
-        Logger::logfw("UltimateAnticheat.log", Warning, L"Failed to open driver service: %d", GetLastError());
+        Logger::logfw(Warning, L"Failed to open driver service: %d", GetLastError());
         CloseServiceHandle(hSCManager);
         return false;
     }
@@ -864,22 +864,22 @@ bool Services::UnloadDriver(const std::wstring& driverName)
 
     if (ControlService(hService, SERVICE_CONTROL_STOP, &status))     //stop driver
     {
-        Logger::logfw("UltimateAnticheat.log", Info, L"Driver stopped successfully.");
+        Logger::logfw(Info, L"Driver stopped successfully.");
     }
     else if (GetLastError() != ERROR_SERVICE_NOT_ACTIVE)
     {
-        Logger::logfw("UltimateAnticheat.log", Warning, L"Failed to stop driver service: %d", GetLastError()); //don't return false yet incase the service was already stopped, in that case delete it
+        Logger::logfw(Warning, L"Failed to stop driver service: %d", GetLastError()); //don't return false yet incase the service was already stopped, in that case delete it
         unloadSuccess = false;
     }
 
     if (!DeleteService(hService))     //delete service
     {
-        Logger::logfw("UltimateAnticheat.log", Warning, L"Failed to delete driver service: %d", GetLastError());
+        Logger::logfw(Warning, L"Failed to delete driver service: %d", GetLastError());
         unloadSuccess = false;
     }
 
     if(unloadSuccess)
-        Logger::logfw("UltimateAnticheat.log", Info, L"Driver %s unloaded successfully.", driverName.c_str());
+        Logger::logfw(Info, L"Driver %s unloaded successfully.", driverName.c_str());
 
     CloseServiceHandle(hService);
     CloseServiceHandle(hSCManager);
@@ -922,7 +922,7 @@ std::string Services::GetProcessDirectory(DWORD pid)
     HANDLE hProcess = OpenProcess(PROCESS_QUERY_INFORMATION | PROCESS_VM_READ, FALSE, pid);
     if (hProcess == nullptr)
     {
-        Logger::logf("UltimateAnticheat.log", Err, "Failed to open process with PID %d @ GetProcessDirectory", pid);
+        Logger::logf(Err, "Failed to open process with PID %d @ GetProcessDirectory", pid);
         return "";
     }
 
@@ -941,12 +941,12 @@ std::string Services::GetProcessDirectory(DWORD pid)
         }
         else
         {
-            Logger::logf("UltimateAnticheat.log", Err, "Failed to find directory in the image path (pid %d) @ GetProcessDirectory", pid);
+            Logger::logf(Err, "Failed to find directory in the image path (pid %d) @ GetProcessDirectory", pid);
         }
     }
     else
     {
-        Logger::logf("UltimateAnticheat.log", Err, "Failed to query process image name with pid %d @ GetProcessDirectory", pid);
+        Logger::logf(Err, "Failed to query process image name with pid %d @ GetProcessDirectory", pid);
     }
 
     CloseHandle(hProcess);
@@ -965,7 +965,7 @@ wstring Services::GetProcessDirectoryW(DWORD pid)
 
     if (hProcess == nullptr)
     {
-        Logger::logf("UltimateAnticheat.log", Err, "Failed to open process with PID %d @ GetProcessDirectory", pid);
+        Logger::logf(Err, "Failed to open process with PID %d @ GetProcessDirectory", pid);
         return L"";
     }
 
@@ -986,12 +986,12 @@ wstring Services::GetProcessDirectoryW(DWORD pid)
         }
         else
         {
-            Logger::logf("UltimateAnticheat.log", Err, "Failed to find directory in the image path (pid %d) @ GetProcessDirectory", pid);
+            Logger::logf(Err, "Failed to find directory in the image path (pid %d) @ GetProcessDirectory", pid);
         }
     }
     else
     {
-        Logger::logf("UltimateAnticheat.log", Err, "Failed to query process image name with pid %d @ GetProcessDirectory", pid);
+        Logger::logf(Err, "Failed to query process image name with pid %d @ GetProcessDirectory", pid);
     }
 
 

--- a/Network/HttpClient.cpp
+++ b/Network/HttpClient.cpp
@@ -51,7 +51,7 @@ string HttpClient::ReadWebPage(__in const string url, __in const vector<string> 
 
         if (res != CURLE_OK)
         {
-            Logger::logf("UltimateAnticheat.log", Warning, "curl_easy_perform() failed: %s\n", curl_easy_strerror(res));
+            Logger::logf(Warning, "curl_easy_perform() failed: %s\n", curl_easy_strerror(res));
             goto cleanup;
         }
 
@@ -123,7 +123,7 @@ string HttpClient::PostRequest(__in const string url, __in const vector<string> 
 
         if (res != CURLE_OK)
         {
-            Logger::logf("UltimateAnticheat.log", Warning, "curl_easy_perform() failed: %s\n", curl_easy_strerror(res));
+            Logger::logf(Warning, "curl_easy_perform() failed: %s\n", curl_easy_strerror(res));
             goto fail_cleanup;
         }
 
@@ -136,7 +136,7 @@ string HttpClient::PostRequest(__in const string url, __in const vector<string> 
     }
     else
     {
-        Logger::logf("UltimateAnticheat.log", Err, "Failed to initialize libcurl @ WeAuth::SignOut");
+        Logger::logf(Err, "Failed to initialize libcurl @ WeAuth::SignOut");
         return "";
     }
 

--- a/Network/NetClient.cpp
+++ b/Network/NetClient.cpp
@@ -52,7 +52,7 @@ Error NetClient::Initialize(string ip, uint16_t port, string gameCode)
 
 	if (RecvLoopThread->GetHandle() == INVALID_HANDLE_VALUE || RecvLoopThread->GetHandle() == NULL)
 	{
-		Logger::logf("UltimateAnticheat.log", Err, "RecvThread was NULL @ NetClient::Initialize");
+		Logger::logf(Err, "RecvThread was NULL @ NetClient::Initialize");
 		closesocket(Socket);
 		WSACleanup();
 		shutdown(Socket, 0);
@@ -140,13 +140,13 @@ void NetClient::ProcessRequests(LPVOID Param)
 	const int ms_between_loops = 1000;
 	unsigned char recvBuf[DEFAULT_RECV_LENGTH] = { 0 };
 
-	Logger::logf("UltimateAnticheat.log", Info, "Started thread on NetClient::ProcessRequests with id: %d", GetCurrentThreadId());
+	Logger::logf(Info, "Started thread on NetClient::ProcessRequests with id: %d", GetCurrentThreadId());
 
 	NetClient* Client = reinterpret_cast<NetClient*>(Param);
 
 	if (Client == nullptr)
 	{
-		Logger::logf("UltimateAnticheat.log", Err, "Client was NULL @ NetClient::ProcessRequests");
+		Logger::logf(Err, "Client was NULL @ NetClient::ProcessRequests");
 		receiving = false; //todo: send signals to rest of anticheat to shutdown
 		goto end;
 	}
@@ -177,7 +177,7 @@ void NetClient::ProcessRequests(LPVOID Param)
 		}
 		else if(s == SOCKET_ERROR)
 		{
-			Logger::logf("UltimateAnticheat.log", Err, "Socket error @  NetClient::ProcessRequests");
+			Logger::logf(Err, "Socket error @  NetClient::ProcessRequests");
 			receiving = false; //todo: send signals to rest of anticheat to shutdown
 		}
 
@@ -269,7 +269,7 @@ Error NetClient::HandleInboundPacket(PacketReader* p)
 		{
 			uint16_t softwareVersion = p->readShort();
 			HandshakeCompleted = true;
-			Logger::logf("UltimateAnticheat.log", Info, "Got reply from server with version: %d", softwareVersion);
+			Logger::logf(Info, "Got reply from server with version: %d", softwareVersion);
 		}break;
 
 		case Packets::Opcodes::SC_HEARTBEAT: //auth cookie every few minutes
@@ -289,7 +289,7 @@ Error NetClient::HandleInboundPacket(PacketReader* p)
 
 				if (SendData(Response) != Error::OK)
 				{
-					Logger::logf("UltimateAnticheat.log", Err, "Could not send heartbeat @ HandleInboundPacket");
+					Logger::logf(Err, "Could not send heartbeat @ HandleInboundPacket");
 					err = Error::BAD_HEARTBEAT;
 				}
 
@@ -298,7 +298,7 @@ Error NetClient::HandleInboundPacket(PacketReader* p)
 			}
 			else
 			{
-				Logger::logf("UltimateAnticheat.log", Err, "Failed to generate heartbeat @ HandleInboundPacket");
+				Logger::logf(Err, "Failed to generate heartbeat @ HandleInboundPacket");
 				err = Error::BAD_HEARTBEAT;
 			}
 		}break;
@@ -310,7 +310,7 @@ Error NetClient::HandleInboundPacket(PacketReader* p)
 
 			if (QueryMemory(address, size) != Error::OK)
 			{
-				Logger::logf("UltimateAnticheat.log", Err, "Could not query memory bytes for server auth @ HandleInboundPacket");
+				Logger::logf(Err, "Could not query memory bytes for server auth @ HandleInboundPacket");
 				err = Error::GENERIC_FAIL;
 			}
 		}break;
@@ -341,7 +341,7 @@ Error NetClient::QueryMemory(uint64_t address, uint32_t size)
 {
 	if (size == 0 || address == 0)
 	{
-		Logger::logf("UltimateAnticheat.log", Err, "Failed to fetch bytes at memory address (size or address was 0) @ NetClient::QueryMemory");
+		Logger::logf(Err, "Failed to fetch bytes at memory address (size or address was 0) @ NetClient::QueryMemory");
 		return Error::INCOMPLETE_SEND;
 	}
 
@@ -349,7 +349,7 @@ Error NetClient::QueryMemory(uint64_t address, uint32_t size)
 
 	if (bytes == nullptr)
 	{
-		Logger::logf("UltimateAnticheat.log", Err, "Failed to fetch bytes at memory address @ NetClient::QueryMemory");
+		Logger::logf(Err, "Failed to fetch bytes at memory address @ NetClient::QueryMemory");
 		return Error::NULL_MEMORY_REFERENCE;
 	}
 
@@ -367,7 +367,7 @@ __forceinline const char* NetClient::MakeHeartbeat(string cookie)
 {
 	if (!Process::IsReturnAddressInModule(*(UINT64*)_AddressOfReturnAddress(), NULL)) //return address check
 	{
-		Logger::logf("UltimateAnticheat.log", Detection, "Return address was outside of module @ NetClient::MakeHeartbeat : some attacker might be trying to spoof heartbeats");
+		Logger::logf(Detection, "Return address was outside of module @ NetClient::MakeHeartbeat : some attacker might be trying to spoof heartbeats");
 		return nullptr;
 	}
 
@@ -418,7 +418,7 @@ string NetClient::GetMACAddress()
 	AdapterInfo = (IP_ADAPTER_INFO*)malloc(sizeof(IP_ADAPTER_INFO));
 	if (AdapterInfo == NULL)
 	{
-		Logger::logf("UltimateAnticheat.log", Err, "Error allocating memory needed to call GetAdaptersinfo @ GetMACAddress");
+		Logger::logf(Err, "Error allocating memory needed to call GetAdaptersinfo @ GetMACAddress");
 		delete[] mac_addr;
 		return "";
 	}
@@ -429,7 +429,7 @@ string NetClient::GetMACAddress()
 		AdapterInfo = (IP_ADAPTER_INFO*)malloc(dwBufLen);
 		if (AdapterInfo == NULL)
 		{
-			Logger::logf("UltimateAnticheat.log", Err, "Error allocating memory needed to call GetAdaptersinfo @ GetMACAddress");
+			Logger::logf(Err, "Error allocating memory needed to call GetAdaptersinfo @ GetMACAddress");
 			delete[] mac_addr;
 			return "";
 		}

--- a/Network/NetClient.hpp
+++ b/Network/NetClient.hpp
@@ -39,12 +39,12 @@ public:
 	{
 		if (serverEndpoint == nullptr)
 		{
-			Logger::logf("UltimateAnticheat.log", Warning, "serverEndpoint was nullptr at NetClient::NetClient!");
+			Logger::logf(Warning, "serverEndpoint was nullptr at NetClient::NetClient!");
 		}
 
 		if (port == 0)
 		{
-			Logger::logf("UltimateAnticheat.log", Warning, "Port was 0 at NetClient::NetClient!");
+			Logger::logf(Warning, "Port was 0 at NetClient::NetClient!");
 		}
 
 		if(serverEndpoint != nullptr)

--- a/Preventions.cpp
+++ b/Preventions.cpp
@@ -32,7 +32,7 @@ bool Preventions::RandomizeModuleName()
             delete mod;
         }
 
-        Logger::logfw("UltimateAnticheat.log", Info, L"Changed module name to: %s\n", UnmanagedGlobals::wCurrentModuleName.c_str());
+        Logger::logfw(Info, L"Changed module name to: %s\n", UnmanagedGlobals::wCurrentModuleName.c_str());
     }
 
     delete[] newModuleName;
@@ -53,14 +53,14 @@ Error Preventions::DeployBarrier()
 
     if (!Process::ChangeNumberOfSections(_MAIN_MODULE_NAME, 1)) //change # of sections to 1
     {
-        Logger::logf("UltimateAnticheat.log", Err, "Failed to change number of sections @ Preventions::DeployBarrier");
+        Logger::logf(Err, "Failed to change number of sections @ Preventions::DeployBarrier");
         retError = Error::CANT_APPLY_TECHNIQUE;
     }
 
 #ifndef _DEBUG
     if (!RemapProgramSections()) //anti-memory write on .text through sections remapping, thanks to changeofpace
     {
-        Logger::logf("UltimateAnticheat.log", Err, " Couldn't remap memory @ DeployBarrier!\n");
+        Logger::logf(Err, " Couldn't remap memory @ DeployBarrier!\n");
         retError = Error::CANT_STARTUP;
     }
 #endif
@@ -69,17 +69,17 @@ Error Preventions::DeployBarrier()
 
     if (RandomizeModuleName()) //randomize our main module name at runtime
     {
-        Logger::logf("UltimateAnticheat.log", Info, " Randomized our executable's module's name!");
+        Logger::logf(Info, " Randomized our executable's module's name!");
     }
     else
     {
-        Logger::logf("UltimateAnticheat.log", Err, " Couldn't change our module's name @ Preventions::DeployBarrier");
+        Logger::logf(Err, " Couldn't change our module's name @ Preventions::DeployBarrier");
         retError = Error::CANT_APPLY_TECHNIQUE;
     }
 
     if (!StopAPCInjection()) //patch over ntdll.dll Ordinal8 unnamed function
     {
-        Logger::logf("UltimateAnticheat.log", Err, "Couldn't apply anti-APC technique @ Preventions::DeployBarrier");
+        Logger::logf(Err, "Couldn't apply anti-APC technique @ Preventions::DeployBarrier");
         retError = Error::CANT_APPLY_TECHNIQUE;
     }
 
@@ -106,23 +106,23 @@ bool Preventions::RemapProgramSections()
         {
             if (!RmpRemapImage(ImageBase)) //re-mapping of image to stop patching, and of course we can easily detect if someone bypasses this
             {
-                Logger::logf("UltimateAnticheat.log", Err, " RmpRemapImage failed.\n");
+                Logger::logf(Err, " RmpRemapImage failed.\n");
             }
             else
             {
-                Logger::logf("UltimateAnticheat.log", Info, " Successfully remapped\n");
+                Logger::logf(Info, " Successfully remapped\n");
                 remap_succeeded = true;
             }
         }
         __except (EXCEPTION_EXECUTE_HANDLER)
         {
-            Logger::logf("UltimateAnticheat.log", Err, " Remapping image failed!");
+            Logger::logf(Err, " Remapping image failed!");
             return false;
         }
     }
     else
     {
-        Logger::logf("UltimateAnticheat.log", Err, " Imagebase was NULL @ RemapAndCheckPages!\n");
+        Logger::logf(Err, " Imagebase was NULL @ RemapAndCheckPages!\n");
         return false;
     }
 
@@ -140,7 +140,7 @@ bool Preventions::StopMultipleProcessInstances()
 
     if (hSharedMemory == NULL)
     {
-        Logger::logf("UltimateAnticheat.log", Err, "Failed to create shared memory. Error code: %lu\n", GetLastError());
+        Logger::logf(Err, "Failed to create shared memory. Error code: %lu\n", GetLastError());
         return false;
     }
 
@@ -148,7 +148,7 @@ bool Preventions::StopMultipleProcessInstances()
 
     if (pIsRunning == NULL)
     {
-        Logger::logf("UltimateAnticheat.log", Err, "Failed to map view of file. Error code : % lu\n", GetLastError());
+        Logger::logf(Err, "Failed to map view of file. Error code : % lu\n", GetLastError());
         CloseHandle(hSharedMemory);
         return false;
     }
@@ -176,7 +176,7 @@ bool Preventions::StopAPCInjection()
 
     if (!ntdll)
     {
-        Logger::logf("UltimateAnticheat.log", Err, "Failed to fetch ntdll module @ StopAPCInjection. Error code : % lu\n", GetLastError());
+        Logger::logf(Err, "Failed to fetch ntdll module @ StopAPCInjection. Error code : % lu\n", GetLastError());
         return false;
     }
 
@@ -185,7 +185,7 @@ bool Preventions::StopAPCInjection()
 
     if (!Oridinal8)
     {
-        Logger::logf("UltimateAnticheat.log", Err, "Failed to fetch ntdll.Ordinal8 address @ StopAPCInjection");
+        Logger::logf(Err, "Failed to fetch ntdll.Ordinal8 address @ StopAPCInjection");
         return false;
     }
 
@@ -195,7 +195,7 @@ bool Preventions::StopAPCInjection()
 
         if (!VirtualProtect((LPVOID)Oridinal8, sizeof(byte), PAGE_EXECUTE_READWRITE, &dwOldProt))
         {
-            Logger::logf("UltimateAnticheat.log", Warning, "Failed to call VirtualProtect on Oridinal8 address @ StopAPCInjection: %llX", Oridinal8);
+            Logger::logf(Warning, "Failed to call VirtualProtect on Oridinal8 address @ StopAPCInjection: %llX", Oridinal8);
             return false;
         }
         else
@@ -209,7 +209,7 @@ bool Preventions::StopAPCInjection()
     }
     __except (EXCEPTION_EXECUTE_HANDLER)
     {
-        Logger::logf("UltimateAnticheat.log", Err, "Failed to patch over Ordinal8 address @ StopAPCInjection");
+        Logger::logf(Err, "Failed to patch over Ordinal8 address @ StopAPCInjection");
         return false;
     }
 
@@ -230,7 +230,7 @@ void Preventions::EnableProcessMitigations(bool useDEP, bool useASLR, bool useDy
 
         if (!SetProcessMitigationPolicy(ProcessDEPPolicy, &depPolicy, sizeof(depPolicy)))
         {
-            Logger::logf("UltimateAnticheat.log", Warning, "Failed to set DEP policy @ EnableProcessMitigations: %d", GetLastError());
+            Logger::logf(Warning, "Failed to set DEP policy @ EnableProcessMitigations: %d", GetLastError());
         }
     }
 
@@ -244,7 +244,7 @@ void Preventions::EnableProcessMitigations(bool useDEP, bool useASLR, bool useDy
 
         if (!SetProcessMitigationPolicy(ProcessASLRPolicy, &aslrPolicy, sizeof(aslrPolicy)))
         {
-            Logger::logf("UltimateAnticheat.log", Warning, "Failed to set ASLR policy @ EnableProcessMitigations: %d", GetLastError());
+            Logger::logf(Warning, "Failed to set ASLR policy @ EnableProcessMitigations: %d", GetLastError());
         }
     }
 
@@ -255,7 +255,7 @@ void Preventions::EnableProcessMitigations(bool useDEP, bool useASLR, bool useDy
 
         if (!SetProcessMitigationPolicy(ProcessDynamicCodePolicy, &dynamicCodePolicy, sizeof(dynamicCodePolicy)))
         {
-            Logger::logf("UltimateAnticheat.log", Warning, "Failed to set dynamic code policy @ EnableProcessMitigations: %d", GetLastError());
+            Logger::logf(Warning, "Failed to set dynamic code policy @ EnableProcessMitigations: %d", GetLastError());
         }
     }
 
@@ -267,7 +267,7 @@ void Preventions::EnableProcessMitigations(bool useDEP, bool useASLR, bool useDy
 
         if (!SetProcessMitigationPolicy(ProcessStrictHandleCheckPolicy, &handlePolicy, sizeof(handlePolicy)))
         {
-            Logger::logf("UltimateAnticheat.log", Warning, "Failed to set strict handle check policy @ EnableProcessMitigations: %d", GetLastError());
+            Logger::logf(Warning, "Failed to set strict handle check policy @ EnableProcessMitigations: %d", GetLastError());
         }
     }
 
@@ -278,7 +278,7 @@ void Preventions::EnableProcessMitigations(bool useDEP, bool useASLR, bool useDy
 
         if (!SetProcessMitigationPolicy(ProcessSystemCallDisablePolicy, &syscallPolicy, sizeof(syscallPolicy)))
         {
-            Logger::logf("UltimateAnticheat.log", Warning, "Failed to set system call disable policy @ EnableProcessMitigations: %d", GetLastError());
+            Logger::logf(Warning, "Failed to set system call disable policy @ EnableProcessMitigations: %d", GetLastError());
         }
     }
 }
@@ -343,12 +343,12 @@ BYTE* Preventions::SpoofPEB() //experimental, don't use this right now as it cau
 
     if (newPEBBytes == NULL)
     {
-        Logger::logf("UltimateAnticheat.log", Err, " Failed to copy PEB @ SpoofPEB!");
+        Logger::logf(Err, " Failed to copy PEB @ SpoofPEB!");
         return NULL;
     }
 
     _MYPEB* ourPEB = (_MYPEB*)&newPEBBytes[0];
 
-    Logger::logf("UltimateAnticheat.log", Info, " Being debugged (PEB Spoofing test): %d. Address of new PEB : %llx\n", ourPEB->BeingDebugged, (UINT64)&newPEBBytes[0]);
+    Logger::logf(Info, " Being debugged (PEB Spoofing test): %d. Address of new PEB : %llx\n", ourPEB->BeingDebugged, (UINT64)&newPEBBytes[0]);
     return newPEBBytes;
 }

--- a/Process/Exports.cpp
+++ b/Process/Exports.cpp
@@ -22,7 +22,7 @@ bool Exports::ChangeFunctionName(string dllName, string functionName, string new
 	{
 		if (LoadedImage.MappedAddress == 0)
 		{
-			Logger::logf("UltimateAnticheat.log", Err, "LoadedImage.MappedAddress was 0 at ChangeFunctionName!");
+			Logger::logf(Err, "LoadedImage.MappedAddress was 0 at ChangeFunctionName!");
 			return false;
 		}
 
@@ -43,7 +43,7 @@ bool Exports::ChangeFunctionName(string dllName, string functionName, string new
 
 					if (!VirtualProtect((LPVOID)funcName_Address, 1024, PAGE_EXECUTE_READWRITE, &oldProt))
 					{
-						Logger::logf("UltimateAnticheat.log", Err, "VirtualProtect failed @ Exports::ChangeFunctionName: %d\n", GetLastError());
+						Logger::logf(Err, "VirtualProtect failed @ Exports::ChangeFunctionName: %d\n", GetLastError());
 					}
 					else
 					{
@@ -56,13 +56,13 @@ bool Exports::ChangeFunctionName(string dllName, string functionName, string new
 		}
 		else
 		{
-			Logger::logf("UltimateAnticheat.log", Err, "MapAndLoad failed @ Exports::ChangeFunctionName: %d\n", GetLastError());
+			Logger::logf(Err, "MapAndLoad failed @ Exports::ChangeFunctionName: %d\n", GetLastError());
 			goto ending;
 		}
 	}
 	else
 	{
-		Logger::logf("UltimateAnticheat.log", Err, "ImageExportDirectory was NULL @ Exports::ChangeFunctionName");
+		Logger::logf(Err, "ImageExportDirectory was NULL @ Exports::ChangeFunctionName");
 		return false;
 	}
 

--- a/Process/Handles.cpp
+++ b/Process/Handles.cpp
@@ -9,7 +9,7 @@ std::vector<Handles::SYSTEM_HANDLE> Handles::GetHandles()
     NtQuerySystemInformationFunc NtQuerySystemInformation = (NtQuerySystemInformationFunc)GetProcAddress(GetModuleHandleW(L"ntdll.dll"), "NtQuerySystemInformation");
     if (!NtQuerySystemInformation)
     {
-        Logger::logf("UltimateAnticheat.log", Err, "Could not get NtQuerySystemInformation function address @ Handles::GetHandles");
+        Logger::logf(Err, "Could not get NtQuerySystemInformation function address @ Handles::GetHandles");
         return {};
     }
 
@@ -22,7 +22,7 @@ std::vector<Handles::SYSTEM_HANDLE> Handles::GetHandles()
         buffer = malloc(bufferSize);
         if (!buffer) 
         {
-            Logger::logf("UltimateAnticheat.log", Err, "Memory allocation failed @ Handles::GetHandles");
+            Logger::logf(Err, "Memory allocation failed @ Handles::GetHandles");
             return {};
         }
 
@@ -34,7 +34,7 @@ std::vector<Handles::SYSTEM_HANDLE> Handles::GetHandles()
         }
         else if (!(((NTSTATUS)(status)) >= 0))
         {
-            Logger::logf("UltimateAnticheat.log", Err, "NtQuerySystemInformation failed @ Handles::GetHandles");
+            Logger::logf(Err, "NtQuerySystemInformation failed @ Handles::GetHandles");
             free(buffer);
             return {};
         }
@@ -91,7 +91,7 @@ std::vector<Handles::SYSTEM_HANDLE> Handles::DetectOpenHandlesToProcess()
 
                         if (!foundWhitelisted)
                         {
-                            Logger::logf("UltimateAnticheat.log", Detection, "Handle %d from process %d is referencing our process.", handle.Handle, handle.ProcessId);
+                            Logger::logf(Detection, "Handle %d from process %d is referencing our process.", handle.Handle, handle.ProcessId);
                             handle.ReferencingOurProcess = true;
                             handlesTous.push_back(handle);
                         }

--- a/Process/PEB.cpp
+++ b/Process/PEB.cpp
@@ -31,7 +31,7 @@ void SetPEBAddress(UINT64 address)
 	}
 	__except (EXCEPTION_EXECUTE_HANDLER)
 	{
-		Logger::logf("UltimateAnticheat.log", Err, "Failed at SetPEBAddress: memory exception writing PEB ptr");
+		Logger::logf(Err, "Failed at SetPEBAddress: memory exception writing PEB ptr");
 		return;
 	}
 }
@@ -76,7 +76,7 @@ BYTE* CopyPEBBytes(unsigned int pebSize)
 	BOOL success = ReadProcessMemory(GetCurrentProcess(), pebAddress, peb_bytes, size_copy, NULL);
 	if (!success)
 	{
-		Logger::logf("UltimateAnticheat.log", Err, "Failed to copy PEB bytes. Error: %d\n", GetLastError());
+		Logger::logf(Err, "Failed to copy PEB bytes. Error: %d\n", GetLastError());
 		delete[] peb_bytes;
 		return NULL;
 	}
@@ -94,7 +94,7 @@ BYTE* CopyAndSetPEB()
 	}
 	else
 	{
-		Logger::logf("UltimateAnticheat.log", Err, "Failed to copy PEB bytes. Error: %d\n");
+		Logger::logf(Err, "Failed to copy PEB bytes. Error: %d\n");
 	}
 
 	return newPeb;

--- a/Process/Process.cpp
+++ b/Process/Process.cpp
@@ -96,12 +96,12 @@ bool Process::HasExportedFunction(string dllName, string functionName)
             }
         }
         else
-            Logger::log("UltimateAnticheat.log", Err, " ImageExportDirectory was NULL @ Process::HasExportedFunction");
+            Logger::log(Err, " ImageExportDirectory was NULL @ Process::HasExportedFunction");
         
         UnMapAndLoad(&LoadedImage);
     }
     else
-        Logger::logf("UltimateAnticheat.log", Err, "MapAndLoad failed: %d @ Process::HasExportedFunction \n", GetLastError());
+        Logger::logf(Err, "MapAndLoad failed: %d @ Process::HasExportedFunction \n", GetLastError());
     
 
     return bFound;
@@ -126,7 +126,7 @@ list<ProcessData::Section*>* Process::GetSections(string module)
 
     if (pDoH == NULL || hInst == NULL)
     {
-        Logger::logf("UltimateAnticheat.log", Err, " PIMAGE_DOS_HEADER or hInst was NULL at Process::GetSections\n");
+        Logger::logf(Err, " PIMAGE_DOS_HEADER or hInst was NULL at Process::GetSections\n");
         return Sections;
     }
 
@@ -323,7 +323,7 @@ bool Process::ChangeImageSize(DWORD newEntry)
 
     if (!pNtH) 
     { 
-        Logger::logf("UltimateAnticheat.log", Err, "NTHeader was somehow NULL at ChangeImageSize\n");
+        Logger::logf(Err, "NTHeader was somehow NULL at ChangeImageSize\n");
         return false;
     }
 
@@ -331,7 +331,7 @@ bool Process::ChangeImageSize(DWORD newEntry)
 
     if (!VirtualProtect((LPVOID)pEntry, sizeof(DWORD), PAGE_EXECUTE_READWRITE, &protect))
     {
-        Logger::logf("UltimateAnticheat.log", Err, "VirtualProtect failed at ChangeImageSize: %d\n", GetLastError());
+        Logger::logf(Err, "VirtualProtect failed at ChangeImageSize: %d\n", GetLastError());
         return false;
     }
 
@@ -373,7 +373,7 @@ bool Process::ChangeSizeOfCode(DWORD newEntry) //modify the 'sizeofcode' variabl
 
     if (!pNtH)
     {
-        Logger::logf("UltimateAnticheat.log", Err, " NTHeader was somehow NULL @ ChangeSizeOfCode\n");
+        Logger::logf(Err, " NTHeader was somehow NULL @ ChangeSizeOfCode\n");
         return false;
     }
 
@@ -417,7 +417,7 @@ bool Process::ChangeNumberOfSections(string module, DWORD newSectionsCount)
 
     if (pDoH == NULL || hInst == NULL)
     {
-        Logger::logf("UltimateAnticheat.log", Err, " PIMAGE_DOS_HEADER or hInst was NULL @ Process::ChangeNumberOfSections");
+        Logger::logf(Err, " PIMAGE_DOS_HEADER or hInst was NULL @ Process::ChangeNumberOfSections");
         return false;
     }
 
@@ -428,7 +428,7 @@ bool Process::ChangeNumberOfSections(string module, DWORD newSectionsCount)
 
     if (!VirtualProtect((LPVOID)&pNtH->FileHeader.NumberOfSections, sizeof(DWORD), PAGE_EXECUTE_READWRITE, &dwOldProt))
     {
-        Logger::logf("UltimateAnticheat.log", Err, " VirtualProtect failed @ Process::ChangeNumberOfSections");
+        Logger::logf(Err, " VirtualProtect failed @ Process::ChangeNumberOfSections");
         return false;
     }
 
@@ -436,7 +436,7 @@ bool Process::ChangeNumberOfSections(string module, DWORD newSectionsCount)
 
     if (!VirtualProtect((LPVOID)&pNtH->FileHeader.NumberOfSections, sizeof(DWORD), dwOldProt, &dwOldProt)) //reset page protections
     {
-        Logger::logf("UltimateAnticheat.log", Err, " VirtualProtect (2nd call) failed @ Process::ChangeNumberOfSections");
+        Logger::logf(Err, " VirtualProtect (2nd call) failed @ Process::ChangeNumberOfSections");
         return false;
     }
 
@@ -462,7 +462,7 @@ bool Process::ChangeImageBase(UINT64 newEntry)
 
     if (!pNtH)
     {
-        Logger::logf("UltimateAnticheat.log", Err, "NTHeader was somehow NULL at ChangeImageBase\n");
+        Logger::logf(Err, "NTHeader was somehow NULL at ChangeImageBase\n");
         return false;
     }
 
@@ -613,7 +613,7 @@ UINT64 Process::GetSectionAddress(const char* moduleName, const char* sectionNam
 
     if (hModule == NULL)
     {
-        Logger::logf("UltimateAnticheat.log", Err, " Failed to get module handle: %d @ GetSectionAddress\n", GetLastError());
+        Logger::logf(Err, " Failed to get module handle: %d @ GetSectionAddress\n", GetLastError());
         return 0;
     }
 
@@ -622,14 +622,14 @@ UINT64 Process::GetSectionAddress(const char* moduleName, const char* sectionNam
     PIMAGE_DOS_HEADER pDosHeader = (PIMAGE_DOS_HEADER)baseAddress;
     if (pDosHeader->e_magic != IMAGE_DOS_SIGNATURE)
     {
-        Logger::logf("UltimateAnticheat.log", Err, " Invalid DOS header @ GetSectionAddress.\n");
+        Logger::logf(Err, " Invalid DOS header @ GetSectionAddress.\n");
         return 0;
     }
 
     PIMAGE_NT_HEADERS pNtHeaders = (PIMAGE_NT_HEADERS)(baseAddress + pDosHeader->e_lfanew);
     if (pNtHeaders->Signature != IMAGE_NT_SIGNATURE)
     {
-        Logger::logf("UltimateAnticheat.log", Err, " Invalid NT header @ GetSectionAddress.\n");
+        Logger::logf(Err, " Invalid NT header @ GetSectionAddress.\n");
         return 0;
     }
 
@@ -648,7 +648,7 @@ UINT64 Process::GetSectionAddress(const char* moduleName, const char* sectionNam
         pSectionHeader++;
     }
 
-    Logger::logf("UltimateAnticheat.log", Warning, ".text section not found.\n");
+    Logger::logf(Warning, ".text section not found.\n");
     return 0;
 }
 
@@ -683,7 +683,7 @@ list<ProcessData::ImportFunction*> Process::GetIATEntries()
 
     if (hModule == NULL)
     {
-        Logger::logf("UltimateAnticheat.log", Err, "Couldn't fetch module handle @ Process::GetIATEntries ");
+        Logger::logf(Err, "Couldn't fetch module handle @ Process::GetIATEntries ");
         return (list<ProcessData::ImportFunction*>)NULL;
     }
 
@@ -691,7 +691,7 @@ list<ProcessData::ImportFunction*> Process::GetIATEntries()
 
     if (dosHeader == nullptr)
     {
-        Logger::logf("UltimateAnticheat.log", Err, "Couldn't fetch dosHeader @ Process::GetIATEntries ");
+        Logger::logf(Err, "Couldn't fetch dosHeader @ Process::GetIATEntries ");
         return (list<ProcessData::ImportFunction*>)NULL;
     }
 
@@ -781,7 +781,7 @@ bool Process::FillModuleList()
                 }
                 else
                 {
-                    Logger::logf("UltimateAnticheat.log", Err, "Unable to parse module information @ Process::FillModuleList");
+                    Logger::logf(Err, "Unable to parse module information @ Process::FillModuleList");
                     return false;
                 }
 
@@ -789,14 +789,14 @@ bool Process::FillModuleList()
             }
             else
             {
-                Logger::logf("UltimateAnticheat.log", Err, "Unable to parse module named @ Process::FillModuleList");
+                Logger::logf(Err, "Unable to parse module named @ Process::FillModuleList");
                 return false;
             }
         }
     }
     else
     {
-        Logger::logf("UltimateAnticheat.log", Err, "EnumProcessModules failed @ Process::FillModuleList");
+        Logger::logf(Err, "EnumProcessModules failed @ Process::FillModuleList");
         return false;
     }
 
@@ -828,7 +828,7 @@ bool Process::ModifyTLSCallbackPtr(UINT64 NewTLSFunction)
         }
         __except (EXCEPTION_EXECUTE_HANDLER)
         {
-            Logger::logf("UltimateAnticheat.log", Err, "Failed to write TLS callback ptr  @ Process::ModifyTLSCallbackPtr");
+            Logger::logf(Err, "Failed to write TLS callback ptr  @ Process::ModifyTLSCallbackPtr");
             return false;
         }
     }
@@ -884,7 +884,7 @@ FARPROC Process::_GetProcAddress(PCSTR Module, LPCSTR lpProcName)
         }
         else
         {
-            Logger::logf("UltimateAnticheat.log", Err, "ImageExportDirectory was NULL @ Process::_GetProcAddress with module %s and function %s", Module, lpProcName);
+            Logger::logf(Err, "ImageExportDirectory was NULL @ Process::_GetProcAddress with module %s and function %s", Module, lpProcName);
             UnMapAndLoad(&LoadedImage);
             return NULL;
         }
@@ -893,7 +893,7 @@ FARPROC Process::_GetProcAddress(PCSTR Module, LPCSTR lpProcName)
     }
     else
     {
-        Logger::logf("UltimateAnticheat.log", Err, "MapAndLoad failed @ Process::_GetProcAddress with module %s and function %s", Module, lpProcName);
+        Logger::logf(Err, "MapAndLoad failed @ Process::_GetProcAddress with module %s and function %s", Module, lpProcName);
         return (FARPROC)NULL;
     }
 
@@ -908,7 +908,7 @@ bool Process::IsReturnAddressInModule(UINT64 RetAddr, const wchar_t* module)
 {
     if (RetAddr == 0)
     {
-        Logger::logf("UltimateAnticheat.log", Err, "RetAddr was 0 @ : Process::IsReturnAddressInModule");
+        Logger::logf(Err, "RetAddr was 0 @ : Process::IsReturnAddressInModule");
         return false;
     }
 
@@ -927,7 +927,7 @@ bool Process::IsReturnAddressInModule(UINT64 RetAddr, const wchar_t* module)
 
     if (size == 0)
     {
-        Logger::logf("UltimateAnticheat.log", Err, "size was 0 @ : Process::IsReturnAddressInModule");
+        Logger::logf(Err, "size was 0 @ : Process::IsReturnAddressInModule");
         return false;
     }
 
@@ -959,18 +959,18 @@ wstring Process::GetProcessName(DWORD pid)
             }
             else 
             {
-                Logger::logf("UltimateAnticheat.log", Err, "GetModuleBaseName failed with error %d @  Process::GetProcessName", GetLastError());
+                Logger::logf(Err, "GetModuleBaseName failed with error %d @  Process::GetProcessName", GetLastError());
             }
         }
         else 
         {
-            Logger::logf("UltimateAnticheat.log", Err, "EnumProcessModules failed with error %d @  Process::GetProcessName", GetLastError());
+            Logger::logf(Err, "EnumProcessModules failed with error %d @  Process::GetProcessName", GetLastError());
         }
         CloseHandle(hProcess);
     }
     else 
     {
-        Logger::logf("UltimateAnticheat.log", Err, "OpenProcess failed with error %d @  Process::GetProcessName", GetLastError());
+        Logger::logf(Err, "OpenProcess failed with error %d @  Process::GetProcessName", GetLastError());
     }
 
     return processName;
@@ -1111,14 +1111,14 @@ DWORD Process::GetTextSectionSize(HMODULE hModule)
     PIMAGE_DOS_HEADER dosHeader = (PIMAGE_DOS_HEADER)hModule;
     if (dosHeader->e_magic != IMAGE_DOS_SIGNATURE)
     {
-        Logger::logf("UltimateAnticheat.log", Err, "Invalid DOS signature @ GetTextSectionSize");
+        Logger::logf(Err, "Invalid DOS signature @ GetTextSectionSize");
         return 0;
     }
 
     PIMAGE_NT_HEADERS ntHeaders = (PIMAGE_NT_HEADERS)((BYTE*)hModule + dosHeader->e_lfanew);
     if (ntHeaders->Signature != IMAGE_NT_SIGNATURE)
     {
-        Logger::logf("UltimateAnticheat.log", Err, "Invalid NT signature @ GetTextSectionSize");
+        Logger::logf(Err, "Invalid NT signature @ GetTextSectionSize");
         return 0;
     }
 
@@ -1221,7 +1221,7 @@ std::vector<BYTE> Process::ReadRemoteTextSection(DWORD pid)
     HANDLE hProcess = OpenProcess(PROCESS_QUERY_INFORMATION | PROCESS_VM_READ, FALSE, pid);
     if (!hProcess) 
     {
-        Logger::logf("UltimateAnticheat.log", Err, "Failed to open process. Error: %d", GetLastError());
+        Logger::logf(Err, "Failed to open process. Error: %d", GetLastError());
         return {};
     }
 
@@ -1230,7 +1230,7 @@ std::vector<BYTE> Process::ReadRemoteTextSection(DWORD pid)
 
     if (!GetRemoteTextSection(hProcess, baseAddress, sectionSize)) 
     {
-        Logger::log("UltimateAnticheat.log", Err, "Failed to find the .text section.");
+        Logger::log(Err, "Failed to find the .text section.");
         CloseHandle(hProcess);
         return {};
     }
@@ -1240,7 +1240,7 @@ std::vector<BYTE> Process::ReadRemoteTextSection(DWORD pid)
     SIZE_T bytesRead = 0;
     if (!ReadProcessMemory(hProcess, reinterpret_cast<LPCVOID>(baseAddress), buffer.data(), sectionSize, &bytesRead)) 
     {
-        Logger::logf("UltimateAnticheat.log", Err, "Failed to read memory. Error: %d",  GetLastError());
+        Logger::logf(Err, "Failed to read memory. Error: %d",  GetLastError());
         CloseHandle(hProcess);
         return {};
     }

--- a/Process/Process.hpp
+++ b/Process/Process.hpp
@@ -89,7 +89,7 @@ public:
 		
 		if (!FillModuleList())
 		{
-			Logger::logf("UltimateAnticheat.log", Err, "Unable to traverse loaded modules @ ::Process() .\n");
+			Logger::logf(Err, "Unable to traverse loaded modules @ ::Process() .\n");
 		}
 
 		SetParentName(GetProcessName(GetParentProcessId()));

--- a/Process/Thread.cpp
+++ b/Process/Thread.cpp
@@ -30,7 +30,7 @@ bool Thread::BeginExecution(LPTHREAD_START_ROUTINE toExecute, LPVOID lpOptionalP
         }
         catch (const std::system_error& e)
         {
-            Logger::logf("UltimateAnticheat.log", Err, "std::thread failed @ BeginExecution: %s\n", e.what());
+            Logger::logf(Err, "std::thread failed @ BeginExecution: %s\n", e.what());
             this->Id = NULL;
             return false;
         }
@@ -52,7 +52,7 @@ bool Thread::IsThreadRunning(HANDLE threadHandle)
         return (exitCode == STILL_ACTIVE);
     }
 
-    Logger::logf("UltimateAnticheat.log", Err, " GetExitCodeThread failed @ IsThreadRunning: %d\n", GetLastError());
+    Logger::logf(Err, " GetExitCodeThread failed @ IsThreadRunning: %d\n", GetLastError());
     return false;
 }
 

--- a/Process/Thread.hpp
+++ b/Process/Thread.hpp
@@ -26,7 +26,7 @@ public:
 	{
 		if (!BeginExecution(toExecute, lpOptionalParam, shouldRunForever, shouldDetach))
 		{
-			Logger::logf("UltimateAnticheat.log", Err, "Thread which was scheduled to execute at: %llX failed to spawn", this->ExecutionAddress);
+			Logger::logf(Err, "Thread which was scheduled to execute at: %llX failed to spawn", this->ExecutionAddress);
 
 			//std::terminate();  //Optionally, terminate the program since a scheduled thread could not start properly. Integrity cannot be guaranteed if one or more threads fails
 		}
@@ -36,7 +36,7 @@ public:
 
 	~Thread()
 	{
-		Logger::logf("UltimateAnticheat.log", Info, "Ending thread which originally executed at: %llX", this->ExecutionAddress);
+		Logger::logf(Info, "Ending thread which originally executed at: %llX", this->ExecutionAddress);
 
 		if (this->t.joinable())
 		{
@@ -49,7 +49,7 @@ public:
 
 				if (std::chrono::duration_cast<std::chrono::seconds>(std::chrono::high_resolution_clock::now() - start).count() >= 10)  // If 10 seconds have passed, exit the loop
 				{
-					Logger::logf("UltimateAnticheat.log", Warning, "Thread did not finish execution within the timeout period.");
+					Logger::logf(Warning, "Thread did not finish execution within the timeout period.");
 					break;
 				}
 

--- a/SplashScreen.cpp
+++ b/SplashScreen.cpp
@@ -75,7 +75,7 @@ LRESULT CALLBACK Splash::SplashWndProc(HWND hWnd, UINT message, WPARAM wParam, L
 
         if (imgWidth == 0 || imgHeight == 0) //failed to fetch image, check path
         {
-            Logger::logf("UltimateAnticheat.log", Warning, "Failed to load splash screen: please ensure splash.png is in the current folder or project root folder.");
+            Logger::logf(Warning, "Failed to load splash screen: please ensure splash.png is in the current folder or project root folder.");
             return 0;
         }
 

--- a/main.cpp
+++ b/main.cpp
@@ -48,7 +48,7 @@ int main(int argc, char** argv)
     bool bCheckHypervisor = true;
     bool bRequireRunAsAdministrator = true;
     bool bUsingDriver = false; //signed driver for hybrid KM + UM anticheat. the KM driver will not be public, so make one yourself if you want to use this option
-    bool logToFile = true;
+    bool enableLogging = true;
     const std::list<std::wstring> allowedParents = {L"VsDebugConsole.exe", L"vsdbg.exe", L"powershell.exe", L"bash.exe", L"zsh.exe", L"explorer.exe"};
 
 #else
@@ -61,7 +61,7 @@ int main(int argc, char** argv)
     bool bCheckThreadIntegrity = true;
     bool bCheckHypervisor = true;
     bool bRequireRunAsAdministrator = true;
-    bool logToFile = true; // set to false to not create a detailed AntiCheat log file on the user's system
+    bool enableLogging = true; // set to false to not create a detailed AntiCheat log file on the user's system
     bool bUsingDriver = false; //signed driver for hybrid KM + UM anticheat. the KM driver will not be public, so make one yourself if you want to use this option
     const std::list<std::wstring> allowedParents = {L"explorer.exe", L"steam.exe"}; //add your launcher here
 #endif
@@ -82,7 +82,7 @@ int main(int argc, char** argv)
         wcout << parent << " ";
     }
     cout << "\n";
-    cout << "\tEnable logging to file:\t\t" << boolalpha << logToFile << "\n";
+    cout << "\tEnable logging :\t\t" << boolalpha << enableLogging << "\n";
 #endif
 
     const int MillisecondsBeforeShutdown = 120000;
@@ -100,7 +100,7 @@ int main(int argc, char** argv)
     cout << "|           discriminating@github (dll load notifcations, catalog verification)          |\n";
     cout << "------------------------------------------------------------------------------------------\n";
 
-    shared_ptr<Settings> ConfigInstance = Settings::CreateInstance(bEnableNetworking, bEnforceSecureBoot, bEnforceDSE, bEnforceNoKDBG, bUseAntiDebugging, bUseIntegrityChecking, bCheckThreadIntegrity, bCheckHypervisor, bRequireRunAsAdministrator, bUsingDriver, allowedParents, logToFile);
+    shared_ptr<Settings> ConfigInstance = Settings::CreateInstance(bEnableNetworking, bEnforceSecureBoot, bEnforceDSE, bEnforceNoKDBG, bUseAntiDebugging, bUseIntegrityChecking, bCheckThreadIntegrity, bCheckHypervisor, bRequireRunAsAdministrator, bUsingDriver, allowedParents, enableLogging);
 
     if (ConfigInstance->bRequireRunAsAdministrator)
     {

--- a/main.cpp
+++ b/main.cpp
@@ -165,12 +165,11 @@ int main(int argc, char** argv)
     catch (const std::bad_alloc& e)
     {
         Logger::logf(Err, "Anticheat pointer could not be allocated @ main(): %s", e.what());
-        std::terminate();
+        return 1;
     }
-
-    if (API::Dispatch(Anti_Cheat.get(), API::DispatchCode::INITIALIZE) != Error::OK) //initialize AC , this will start all detections + preventions
+    catch (const AntiCheatInitFail& e)
     {
-        Logger::logf(Err, "Could not initialize program: API::Dispatch failed. Shutting down.");
+        Logger::logf(Err, "Anticheat init error: %d %s", e.reasonEnum, e.what());
         return 1;
     }
 

--- a/main.cpp
+++ b/main.cpp
@@ -49,7 +49,7 @@ int main(int argc, char** argv)
     bool bRequireRunAsAdministrator = true;
     bool bUsingDriver = false; //signed driver for hybrid KM + UM anticheat. the KM driver will not be public, so make one yourself if you want to use this option
     bool logToFile = true;
-    const std::list<std::wstring> allowedParents = {L"VsDebugConsole.exe", L"powershell.exe", L"bash.exe", L"zsh.exe", L"explorer.exe"};
+    const std::list<std::wstring> allowedParents = {L"VsDebugConsole.exe", L"vsdbg.exe", L"powershell.exe", L"bash.exe", L"zsh.exe", L"explorer.exe"};
 
 #else
     bool bEnableNetworking = false; //change this to false if you don't want to use the server


### PR DESCRIPTION
Hi!
Still doing some changes and tweaks instead of checking on a godot port, but I try improving on the bugs/frustrations I met when discovering the project, and make it more configurable when finally porting to Godot.

I still try to fix the cmake build, but it's never perfect, and, notice, at first build you have to move the DLLs to the build directory once  (but won't fix because in the end, I don't use cmake, sorry)

Most important change today (that affects almost all the files) is the log file name put in a static variable at `Settings` init instead of putting it on every log call.

for the Wiki, I still can't edit it, you have to set it to public manually, as says [Github documentation on wiki permissions](https://docs.github.com/en/communities/documenting-your-project-with-wikis/changing-access-permissions-for-wikis)

#### the strange case of the shrodinger mutex

I finally managed to debug the app with Visual Studio... I just had to update my Studio version, that was pretty old!
But this strange behavior hides an undefined one:
turns out it was indeed because of this mutex initialization in log methods.

https://github.com/AlSch092/UltimateAntiCheat/blob/86c8d1996fd4605499f9f141887a85ab34381bda/Common/Logger.hpp#L37

We have a static mutex, called from a static method, so there is an undefined behavior on who will be initialized first. it works fine *most of the time*, but in my case I had a crash specifically with the debugger, and it could happen to anyone on any platform I guess...
the [inline keyword seems to fix this](https://stackoverflow.com/a/75823231/7968088) , but it seems to be a cpp17 feature :/ .
So maybe this mutex line needs a rework, static variables look wonky...
> I love cpp, I love uninitialized variables, I love unhandlable exceptions, I love undefined behaviors!!!! 

