### PR TITLE
Big changes: Trying to prevent infinite hangups and stop gracefully the anticheat

### DIFF
--- a/API/API.cpp
+++ b/API/API.cpp
@@ -75,6 +75,7 @@ Error API::Cleanup(AntiCheat* AC)
 	if (AC->GetMonitor()->GetMonitorThread() != NULL) //stop anti-cheat monitor thread
 	{
 		AC->GetMonitor()->GetMonitorThread()->SignalShutdown(true);
+		AC->GetMonitor()->monitorProcessCreationMutex.lock();
 		WaitForSingleObject(AC->GetMonitor()->GetMonitorThread()->GetHandle(), 6000);
 	}
 

--- a/AntiCheatInitFail.hpp
+++ b/AntiCheatInitFail.hpp
@@ -5,41 +5,50 @@
 
 enum AntiCheatInitFailReason
 {
-    NullSettings, BadAlloc, DriverNotFound, DriverUnsigned, DriverLoadFail, DispatchFail
+    NullSettings, BadAlloc, DriverNotFound, DriverUnsigned, DriverLoadFail, DispatchFail, NotAdministrator, NoSecureBoot, TestSigningEnabled, HypervisorPresent
 };
 
-class AntiCheatInitFail : public std::exception 
+class AntiCheatInitFail : public std::exception
 {
     public:
 		AntiCheatInitFailReason reasonEnum;
 
 		AntiCheatInitFail(AntiCheatInitFailReason reason) : reasonEnum(reason) {}
 
-		const char * what () const throw() 
+		const char * what () const throw()
 		{
 			return reasonExplainMap.at(reasonEnum).c_str();
 		}
 
 	private:
 	#ifdef _DEBUG
-		const std::map<AntiCheatInitFailReason, const std::string> reasonExplainMap = 
+		const std::map<AntiCheatInitFailReason, const std::string> reasonExplainMap =
 		{
 			{ NullSettings, "Settings pointer was NULL" },
 			{ BadAlloc, "Critical allocation failure" },
 			{ DriverNotFound, "Could not  get absolute path from driver relative path" },
 			{ DriverUnsigned, "Driver certificate subject/signer was not correct" },
 			{ DriverLoadFail, "Could not load driver" },
-			{ DispatchFail, "API::Dispatch failed" }
+			{ DispatchFail, "API::Dispatch failed" },
+			{ NotAdministrator, "Program must be running as administrator in order to proceed, or change `bRequireRunAsAdministrator` to false." },
+			{ NoSecureBoot, "Secure boot is not enabled, you cannot proceed. Please enable secure boot in your BIOS or change `bEnforceSecureBoot` to false." },
+			{ TestSigningEnabled, "Test signing was enabled, you cannot proceed. Please turn off test signing via `bcdedit.exe`, or change `bEnforceDSE` to false." },
+			{ HypervisorPresent, "Hypervisor was present with unknown/non-standard vendor." }
 		};
 	#else
-	const std::map<AntiCheatInitFailReason, const std::string> reasonExplainMap = 
+	const std::map<AntiCheatInitFailReason, const std::string> reasonExplainMap =
 	{
 			{ NullSettings, "" },
 			{ BadAlloc, "" },
 			{ DriverNotFound, "" },
 			{ DriverUnsigned, "" },
 			{ DriverLoadFail, "" },
-			{ DispatchFail, "" }
+			{ DispatchFail, "" },
+			{ NotAdministrator, "" },
+			{ NoSecureBoot, "" },
+			{ TestSigningEnabled, "" },
+			{ HypervisorPresent, "" }
+
     };
 	#endif
 };

--- a/AntiTamper/Integrity.cpp
+++ b/AntiTamper/Integrity.cpp
@@ -1,4 +1,5 @@
 //By AlSch092 @github
+#include "../Detections.hpp"
 #include "Integrity.hpp"
 
 /*
@@ -87,7 +88,7 @@ void Integrity::SetSectionHashList(__out vector<uint64_t> hList, __in const stri
 	IsUnknownModulePresent - compares current module list to one gathered at program startup, any delta modules are checked via WinVerifyTrust and added to our `WhitelistedModules` member
 	return true if an unsigned module (besides current executable) was found
 */
-bool Integrity::IsUnknownModulePresent()
+bool Integrity::IsUnknownModulePresent(Detections *Monitor)
 {
 	bool foundUnknown = false;
 
@@ -96,6 +97,10 @@ bool Integrity::IsUnknownModulePresent()
 
 	for (auto it = currentModules.begin(); it != currentModules.end(); ++it)  //if an attacker signs their dll, they'll be able to get past this
 	{
+		if (!Monitor->isMonitoring) { //program ends, stop all signature checks
+			break;
+		}
+
 		bool found_whitelisted = false;
 
 		for (auto it2 = this->WhitelistedModules.begin(); it2 != this->WhitelistedModules.end(); ++it2) //our whitelisted module list is initially populated inside the constructor with modules gathered at program startup

--- a/AntiTamper/Integrity.hpp
+++ b/AntiTamper/Integrity.hpp
@@ -12,6 +12,8 @@
 
 using namespace std;
 
+class Detections;
+
 struct ModuleHashData 
 {
 	wstring Name;
@@ -78,7 +80,7 @@ public:
 		return {};
 	}
 
-	bool IsUnknownModulePresent(); //traverse loaded modules to find any unknown ones (not signed & not whitelisted, in particular)
+	bool IsUnknownModulePresent(Detections* Monitor); //traverse loaded modules to find any unknown ones (not signed & not whitelisted, in particular)
 
 	vector<ProcessData::MODULE_DATA> GetWhitelistedModules() const { return this->WhitelistedModules; }
 	

--- a/AntiTamper/NAuthenticode.hpp
+++ b/AntiTamper/NAuthenticode.hpp
@@ -27,6 +27,7 @@ namespace Authenticode
 	BOOL VerifyEmbeddedSignature(LPCWSTR pwszSourceFile);
 	BOOL VerifyCatalogSignature(LPCWSTR filePath);
 	BOOL HasSignature(LPCWSTR filePath);
+	BOOL HasSignatureHanging(LPCWSTR filePath);
 	wstring GetSignerFromFile(const wstring& filePath); //get the 'subject' field of the certifcate (often the company which published the software file)
 
 	//https://learn.microsoft.com/en-us/previous-versions/troubleshoot/windows/win32/get-information-authenticode-signed-executables

--- a/Common/Globals.cpp
+++ b/Common/Globals.cpp
@@ -1,0 +1,63 @@
+#include "Globals.hpp"
+
+/*
+    AddThread - adds a Thread* object to our global thread list
+*/
+bool UnmanagedGlobals::AddThread(DWORD id)
+{
+    DWORD tid = GetCurrentThreadId();
+    Logger::logf(Info, " New thread spawned: %d", tid);
+
+    CONTEXT context;
+    context.ContextFlags = CONTEXT_ALL;
+
+    HANDLE threadHandle = OpenThread(THREAD_ALL_ACCESS, FALSE, tid);
+
+    if (threadHandle == NULL)
+    {
+        Logger::logf(Warning, " Couldn't open thread handle @ TLS Callback: Thread %d", tid);
+        return false;
+    }
+    else
+    {
+        Thread* t = new Thread(tid); //memory must be free'd after done using, this function does not free mem
+        UnmanagedGlobals::ThreadList->push_back(t);
+        return true;
+    }
+}
+
+/*
+    RemoveThread - Removes Thread* with threadid `tid` from our global thread list
+*/
+void UnmanagedGlobals::RemoveThread(DWORD tid)
+{
+    Thread* ToRemove = NULL;
+
+    list<Thread*>::iterator it;
+
+    for (it = ThreadList->begin(); it != ThreadList->end(); ++it)
+    {
+        Thread* t = it._Ptr->_Myval;
+        if (t->GetId() == tid)
+            ToRemove = t;
+    }
+
+    if (ToRemove != NULL) //remove thread from our list on thread_detach
+        ThreadList->remove(ToRemove);
+}
+
+/*
+    ExceptionHandler - User defined exception handler which catches program-wide exceptions
+    ...Currently we are not doing anything special with this, but we'll leave it here incase we need it later
+*/
+LONG WINAPI UnmanagedGlobals::ExceptionHandler(EXCEPTION_POINTERS* ExceptionInfo)  //handler that will be called whenever an unhandled exception occurs in any thread of the process
+{
+    DWORD exceptionCode = ExceptionInfo->ExceptionRecord->ExceptionCode;
+    Logger::logf(Warning, "Program threw exception: %x at %llX\n", exceptionCode, ExceptionInfo->ExceptionRecord->ExceptionAddress);
+    
+    if (exceptionCode == EXCEPTION_BREAKPOINT) //one or two of our debug checks may throw this exception
+    {
+    } //optionally we may be able to view the exception address and compare it to whitelisted module address space, if it's not contained then we assume it's attacker-run code
+
+    return EXCEPTION_CONTINUE_SEARCH;
+}

--- a/Detections.hpp
+++ b/Detections.hpp
@@ -11,6 +11,7 @@
 #include "Obscure/ntldr.hpp" //dll notification structures
 #include <Wbemidl.h> //for process event creation (WMI)
 #include <comdef.h>  //for process event creation (WMI)
+#include <mutex>
 
 #pragma comment(lib, "wbemuuid.lib")  //for process event creation (WMI)
 
@@ -90,6 +91,7 @@ public:
 	Detections operator*(Detections& other) = delete;
 	Detections operator/(Detections& other) = delete;
 
+	std::mutex monitorProcessCreationMutex;
 	weak_ptr<NetClient> GetNetClient() { return this->netClient; }
 
 	Services* GetServiceManager() const { return this->_Services.get(); }

--- a/Detections.hpp
+++ b/Detections.hpp
@@ -149,8 +149,10 @@ public:
 
 	static bool DetectManualMapping(__in HANDLE hProcess);
 
-private:
+	//throws AntiCheatInitFail on error
+	static void startupChecks(shared_ptr<Settings> ConfigInstance);
 
+private:
 	shared_ptr<Settings> Config = nullptr; //non-owning pointer to the original unique_ptr<Settings> in main.cpp
 
 	void InitializeBlacklistedProcessesList();

--- a/Detections.hpp
+++ b/Detections.hpp
@@ -74,10 +74,19 @@ public:
 	~Detections()
 	{
 		if (MonitorThread != NULL)
+		{
 			delete MonitorThread;
+			MonitorThread = NULL;
+		}
 
 		if(RegistryMonitorThread != NULL)
+		{
 			delete RegistryMonitorThread;
+			RegistryMonitorThread = NULL;
+		}
+		isMonitoring = false;
+		monitorMutex.lock();
+		monitorCallbackMutex.lock();
 	}
 
 	Detections(Detections&&) = delete;  //delete move constructr
@@ -91,7 +100,11 @@ public:
 	Detections operator*(Detections& other) = delete;
 	Detections operator/(Detections& other) = delete;
 
+	std::mutex monitorMutex;
+	std::mutex monitorCallbackMutex;
 	std::mutex monitorProcessCreationMutex;
+	bool isMonitoring = true;
+
 	weak_ptr<NetClient> GetNetClient() { return this->netClient; }
 
 	Services* GetServiceManager() const { return this->_Services.get(); }

--- a/Init.cpp
+++ b/Init.cpp
@@ -1,0 +1,117 @@
+#include "Init.hpp"
+#include "Preventions.hpp"
+#include "Common/Globals.hpp"
+
+/*
+The TLS callback triggers on process + thread attachment & detachment, which means we can catch any threads made by an attacker in our process space.
+We can end attacker threads using ExitThread(), and let in our threads which are managed.
+...An attacker can circumvent this by modifying the pointers to TLS callbacks which the program usually keeps track of, which requires re-remapping
+*/
+void NTAPI __stdcall TLSCallback(PVOID pHandle, DWORD dwReason, PVOID Reserved)
+{
+    const UINT ThreadExecutionAddressStackOffset = 0x378; //** this might change on different version of window, Windows 10 is all I have access to currently
+
+    switch (dwReason)
+    {
+        case DLL_PROCESS_ATTACH:
+        {
+            if (!Preventions::StopMultipleProcessInstances()) //prevent multi-clients by using shared memory-mapped region
+            {
+                Logger::logf(Err, "Could not initialize program: shared memory check failed, make sure only one instance of the program is open. Shutting down.");
+                terminate();
+            }
+
+            Logger::logf(Info, " New process attached, current thread %d\n", GetCurrentThreadId());
+
+            if (UnmanagedGlobals::FirstProcessAttach) //process creation will trigger PROCESS_ATTACH, so we can put some initialize stuff in here incase main() is hooked or statically modified by the attacker
+            {
+                if (!UnmanagedGlobals::SetExceptionHandler)
+                {
+                    SetUnhandledExceptionFilter(UnmanagedGlobals::ExceptionHandler);
+
+                    if (!AddVectoredExceptionHandler(1, UnmanagedGlobals::ExceptionHandler))
+                    {
+                        Logger::logf(Err, " Failed to register Vectored Exception Handler @ TLSCallback: %d\n", GetLastError());
+                    }
+
+                    UnmanagedGlobals::SetExceptionHandler = true;
+                }
+
+                UnmanagedGlobals::FirstProcessAttach = false;
+            }
+            else
+            {
+                Logger::logf(Detection, " Some unknown process attached @ TLSCallback "); //this should generally never be triggered in this example
+            }
+        }break;
+
+        case DLL_PROCESS_DETACH: //program exit, clean up any memory allocated
+        {
+            UnmanagedGlobals::ThreadList->clear();
+            delete UnmanagedGlobals::ThreadList;
+        }break;
+
+        case DLL_THREAD_ATTACH: //add to our thread list, or if thread is not executing valid address range, patch over execution address
+        {         
+#ifndef _DEBUG
+            if (!Debugger::AntiDebug::HideThreadFromDebugger(GetCurrentThread())) //hide thread from debuggers, placing this in the TLS callback allows all threads to be hidden
+            {
+                Logger::logf(Warning, " Failed to hide thread from debugger @ TLSCallback: thread id %d\n", GetCurrentThreadId());
+            }
+#endif
+            if (!UnmanagedGlobals::AddThread(GetCurrentThreadId()))
+            {
+                Logger::logf(Err, " Failed to add thread to ThreadList @ TLSCallback: thread id %d\n", GetCurrentThreadId());
+            }
+
+            if (UnmanagedGlobals::SupressingNewThreads)
+            {
+                if (Services::GetWindowsVersion() == Windows11) //Windows 11 no longer has the thread's start address on the its stack, bummer
+                    return;
+
+                UINT64 ThreadExecutionAddress = *(UINT64*)((UINT64)_AddressOfReturnAddress() + ThreadExecutionAddressStackOffset); //check down the stack for the thread execution address, compare it to good module range, and if not in range then we've detected a rogue thread
+                
+                if (ThreadExecutionAddress == 0) //this generally should never be 0, but we'll add a check for good measure incase the offset changes on different W10 builds
+                    return;
+
+                auto modules = Process::GetLoadedModules();
+
+                for (auto module : modules)
+                {
+                    UINT64 LowAddr = (UINT64)module.dllInfo.lpBaseOfDll;
+                    UINT64 HighAddr = (UINT64)module.dllInfo.lpBaseOfDll + module.dllInfo.SizeOfImage;
+
+                    if (ThreadExecutionAddress > LowAddr && ThreadExecutionAddress < HighAddr) //a properly loaded DLL is making the thread, so allow it to execute
+                    {
+                        //if any unsigned .dll is loaded, it will be caught in the DLL load callback/notifications, so we shouldnt need to cert check in this routine (this will cause slowdowns in execution, also cert checking inside the TLS callback doesn't seem to work properly here)
+                        return; //any manually mapped modules' threads will be stopped since they arent using the loader and thus won't be in the loaded modules list
+                    }
+                }
+
+                Logger::logf(Info, " Stopping unknown thread from being created  @ TLSCallback: thread id %d", GetCurrentThreadId());
+                Logger::logf(Info, " Thread id %d wants to execute function @ %llX. Patching over this address.", GetCurrentThreadId(), ThreadExecutionAddress);
+
+                DWORD dwOldProt = 0;
+
+                if(!VirtualProtect((LPVOID)ThreadExecutionAddress, sizeof(byte), PAGE_EXECUTE_READWRITE, &dwOldProt)) //make thread start address writable
+                {
+                    Logger::logf(Warning, "Failed to call VirtualProtect on ThreadStart address @ TLSCallback: %llX", ThreadExecutionAddress);
+                }
+                else
+                {
+                    if (ThreadExecutionAddress != 0)
+                    {
+                        *(BYTE*)ThreadExecutionAddress = 0xC3; //write over any functions which are scheduled to execute next by this thread and not inside our whitelisted address range
+                        VirtualProtect((LPVOID)ThreadExecutionAddress, sizeof(byte), PAGE_READONLY, &dwOldProt); // (optional) take away executable protections for the rogue thread's start address
+                    }
+                }
+            }
+
+        }break;
+
+        case DLL_THREAD_DETACH:
+        {
+            UnmanagedGlobals::RemoveThread(GetCurrentThreadId());
+        }break;
+    };
+}

--- a/Init.hpp
+++ b/Init.hpp
@@ -1,0 +1,20 @@
+#include "API/API.hpp"
+
+#pragma comment(linker, "/ALIGN:0x10000") //for remapping technique (anti-tamper) - each section gets its own region, align with system allocation granularity
+
+using namespace std;
+
+void NTAPI __stdcall TLSCallback(PVOID pHandle, DWORD dwReason, PVOID Reserved);
+
+#pragma comment (linker, "/INCLUDE:_tls_used")
+#pragma comment (linker, "/INCLUDE:_tls_callback")
+
+EXTERN_C
+#ifdef _M_X64
+#pragma const_seg (".CRT$XLB")
+const
+#endif
+
+PIMAGE_TLS_CALLBACK _tls_callback = TLSCallback;
+#pragma data_seg ()
+#pragma const_seg ()


### PR DESCRIPTION
Hi, today , what was supposed to be a  [simple 20 minutes adventure](https://www.youtube.com/shorts/CVQG87UYDN0) bugfix got to a massive rabbit hole with major changes, discoveries, and a renewed hatred of C++.
Please review the changes and maybe tests them, because I think I have fixed multiple issues, but I don't know if I created new ones, or if they just appeared to me because the code triggering them was not executed before, blocked by hanging calls 🤣

So to summarize, I wanted to create a small example of the anti-cheat where I start it, and then stop it, gracefully.
Then I noticed that in the first `API::Dispatch` init call, it hanged due to `GetUnsignedDrivers` , calling `HasSignature`, the culprit being always this line infinitely hanging:
https://github.com/AlSch092/UltimateAntiCheat/blob/95c8b23264d5f7c66f26f332c71d9334895015b9/AntiTamper/NAuthenticode.cpp#L36

I created an [Stackoverflow issue](https://stackoverflow.com/questions/79446099/winverifytrust-hangs-or-crashes-with-certain-dlls) on the subject, but people seem to be nitpicking on it for now, they ask me to take 3 hours creating an mvp for them . Still I'm certain if I do it they won't help me anyway ^^'

So for now, breaking change n°1: **I put `HasSignature` in threads with a 15 seconds timeout**.
It's not great, but at least now the rest of the anti cheat can work instead of hanging whole threads.

Now that the AntiCheat could finally startup... *I couldn't stop it!*


There were a few infinite loops in the detection threads, so if you called the destructors, it would either hang infinitely, or crash the process, because the thread would be deleted while code inside was running, or the Monitor would be deleted before its thread, but the thread has access to the monitor... well, it made the app crash, and I would like to have a clean shutdown of my process.

I also reworked the main, move the startup calls that the user should'nt normally call manually, and expand on an example, now instead of sleeping 2 minutes, it runs indefinitely, but if you press a key, the program shuts down.

I have still a **known issue** , I tried everything but this line still ocasionally crashes at AntiCheat deletion, 

https://github.com/AlSch092/UltimateAntiCheat/blob/9e92587e8487b60c300306f6569ecd96c7d89647/API/API.cpp#L78

I tried more changes and checks, but I don't know why it sometimes returns a `An invalid handle was specified.`.
Because it's race conditions, I tested the program multiple times, in debug, in release, with and without debugger, with and without being admin... it's still very finnicky and I really don't undertand the root cause, please help!

 But I think now the AntiCheat is a bit more stable, even if quite a bit more convoluted, with conditions and mutexes, in order to signal the threads to stop gracefully their detection works at shutdown without waiting too long.

Also, on release, I have these errors, but [maybe I had them before, just they hadn't the time to trigger due to the blocking signature checks](https://media1.tenor.com/m/ihohWsIjTCcAAAAd/mr-burns-door.gif):

```
[ERROR] RmppVerifyPeSectionAlignment failed.
[ERROR]  RmpRemapImage failed.
[ERROR]  Couldn't remap memory @ DeployBarrier!
...
[ERROR] Could not initialize the barrier @ API::LaunchBasicTests
```
As they are release only checks, it prevents my release build from working for now, because these check fail now throw a `AntiCheatInitFailReason::DispatchFail` on AntiCheat creation

Now I'm really tired, and I think I will take a small pause on this project to avoid burnout, as it is way more complex to tackle than I tought it would be!