### PR TITLE
I fixed it! no more HasSignature hanging (+ performance improv idea)

### DIFF
--- a/Detections.cpp
+++ b/Detections.cpp
@@ -29,42 +29,51 @@ BOOL Detections::StartMonitor()
 /*
     LdrpDllNotification - This function is called whenever a new module is loaded into the process space, called before TLS callbacks
 */
-
 VOID CALLBACK Detections::OnDllNotification(ULONG NotificationReason, const PLDR_DLL_NOTIFICATION_DATA NotificationData, PVOID Context)
 {
     Detections* Monitor = reinterpret_cast<Detections*>(Context);
-    
+
     if (NotificationReason == LDR_DLL_NOTIFICATION_REASON_LOADED)
     {
         LPCWSTR FullDllName = NotificationData->Loaded.FullDllName->pBuffer;
-        Monitor->DLLVerificationQueueMutex.lock();
-        Monitor->DLLVerificationQueue.push(FullDllName);
-        Monitor->DLLVerificationQueueMutex.unlock();
+
+        if (FullDllName != nullptr)
+        {
+            Logger::logfw(Info, L"[LdrpDllNotification Callback] dll loaded: %s\n", FullDllName);
+            std::lock_guard<std::mutex> lock(Monitor->DLLVerificationQueueMutex);
+            Monitor->DLLVerificationQueue.push(wstring(FullDllName));
+        }
     }
 }
 
-/*
-    Detections::Monitor(LPVOID thisPtr)
-     Routine which monitors aspects of the process for fragments of cheating, loops continuously until the thread is signalled to shut down
-*/
 
-void Detections::checkDLLSignature()
+/*
+    CheckDLLSignature - checks the signatures of any newly loaded modules
+*/
+void Detections::CheckDLLSignature()
 {
-    while (true) {
-        this->DLLVerificationQueueMutex.lock();
-        if (this->DLLVerificationQueue.size() == 0) {
-            this->DLLVerificationQueueMutex.unlock();
-            break;
-        }
-        LPCWSTR FullDllName = this->DLLVerificationQueue.front();
-        Logger::logfw(Info, L"[LdrpDllNotification Callback] dll loaded: %s, verifying signature...\n", FullDllName);
-        if (!Authenticode::HasSignature(FullDllName))
+    while (true) 
+    {
+        wstring FullDllName;
+     
+        {
+            std::lock_guard<std::mutex> lock(this->DLLVerificationQueueMutex); //lock only for queue access
+            
+            if (this->DLLVerificationQueue.empty()) 
+            {
+                break;
+            }
+
+            FullDllName = this->DLLVerificationQueue.front();
+            this->DLLVerificationQueue.pop();
+
+        }  //mutex is unlocked here automatically since lock_guard works as a RAII and we create scope with { and }
+ 
+        if (FullDllName.size() > 0 && !Authenticode::HasSignature(FullDllName.c_str())) //now do the expensive work without holding the lock
         {
             Logger::logfw(Detection, L"Failed to verify signature of %s\n", FullDllName);
             this->Flag(DetectionFlags::INJECTED_ILLEGAL_PROGRAM);
         }
-        this->DLLVerificationQueue.pop();
-        this->DLLVerificationQueueMutex.unlock();
     }
 }
 
@@ -158,7 +167,7 @@ void Detections::Monitor(LPVOID thisPtr)
             return;
         }
 
-        Monitor->checkDLLSignature();
+        Monitor->CheckDLLSignature();
 
         if (Monitor->Config->bCheckHypervisor)
         {

--- a/Detections.cpp
+++ b/Detections.cpp
@@ -37,7 +37,7 @@ VOID CALLBACK Detections::OnDllNotification(ULONG NotificationReason, const PLDR
     {
         LPCWSTR FullDllName = NotificationData->Loaded.FullDllName->pBuffer;
 
-        if (FullDllName != nullptr)
+        if (Monitor != nullptr && FullDllName != nullptr)
         {
             Logger::logfw(Info, L"[LdrpDllNotification Callback] dll loaded: %s\n", FullDllName);
             std::lock_guard<std::mutex> lock(Monitor->DLLVerificationQueueMutex);

--- a/Detections.hpp
+++ b/Detections.hpp
@@ -157,8 +157,9 @@ private:
 	bool MonitoringProcessCreation = false;
 
 	void checkDLLSignature();
-	std::queue<LPCWSTR> DLLVerificationQueue;
-	std::mutex DLLVerificationQueueMutex;
+	
+        queue<wstring> DLLVerificationQueue;
+	mutex DLLVerificationQueueMutex;
 
 	ObfuscatedData<uint8_t>* CheaterWasDetected = nullptr; //using bool as the type does not work properly with obfuscation since the compiler uses true/false, so use uint8_t instead and cast to BOOL when needed
 

--- a/Detections.hpp
+++ b/Detections.hpp
@@ -1,5 +1,7 @@
 //By AlSch092 @github
 #pragma once
+#include <queue>
+
 #include "Network/NetClient.hpp" //Net Comms
 #include "Network/HttpClient.hpp"
 #include "AntiDebug/DebuggerDetections.hpp"
@@ -153,6 +155,10 @@ private:
 	static void MonitorProcessCreation(LPVOID thisPtr);
 
 	bool MonitoringProcessCreation = false;
+
+	void checkDLLSignature();
+	std::queue<LPCWSTR> DLLVerificationQueue;
+	std::mutex DLLVerificationQueueMutex;
 
 	ObfuscatedData<uint8_t>* CheaterWasDetected = nullptr; //using bool as the type does not work properly with obfuscation since the compiler uses true/false, so use uint8_t instead and cast to BOOL when needed
 

--- a/main.cpp
+++ b/main.cpp
@@ -8,6 +8,7 @@
     Author: AlSch092 @ Github
 */
 #include <map>
+#include <conio.h>
 
 #include "API/API.hpp"
 #include "AntiCheat.hpp"
@@ -139,20 +140,16 @@ int main(int argc, char** argv)
 
     cout << "\n----------------------------------------------------------------------------------------------------------" << endl;
     cout << "All protections have been deployed, the program will now loop using its detection methods. Thanks for your interest in the project!" << endl;
-    cout << "Please enter 'q' if you'd like to end the program." << endl;
+    cout << "Press any key to end the program." << endl;
     
-    string userInput;
-
+    return 0;
     while (true)
     {
-        cin >> userInput;
-
-        if (userInput == "q")
-        {
-            cout << "Exit key was pressed, shutting down program..." << endl;
+        if (_kbhit())
             break;
-        }     
+        Sleep(100);
     }
+    cout << "Exit key was pressed, shutting down program..." << endl;
 
     if (Anti_Cheat->GetMonitor()->IsUserCheater())
     {

--- a/main.cpp
+++ b/main.cpp
@@ -140,17 +140,21 @@ int main(int argc, char** argv)
 
     cout << "\n----------------------------------------------------------------------------------------------------------" << endl;
     cout << "All protections have been deployed, the program will now loop using its detection methods. Thanks for your interest in the project!" << endl;
-    cout << "Press any key to end the program." << endl;
+    cout << "Please enter 'q' if you'd like to end the program." << endl;
     
-    return 0;
+    string userInput;
+
     while (true)
     {
-        if (_kbhit())
-            break;
-        Sleep(100);
-    }
-    cout << "Exit key was pressed, shutting down program..." << endl;
+        cin >> userInput;
 
+        if (userInput == "q" || userInput == "Q")
+        {
+            cout << "Exit key was pressed, shutting down program..." << endl;
+            break;
+        }     
+    }
+    
     if (Anti_Cheat->GetMonitor()->IsUserCheater())
     {
         Logger::logf(Info, "Detected a possible cheater during program execution!");


### PR DESCRIPTION
Hi!

After so much time on this issue, I finally solved it, you just had to call HasSignature from outside of the `OnDLLNotification` callback, so now the callback only fills a list that the main `Detections::Monitor` loop checks. It may delay the check by a few seconds, but it won't hang anymore 😃 


#### performance improvement ideas

Also, I wanted to understand why the Anti-Cheat constructor took 80 seconds to load for me, and see if we could *"optimize"* (understand : put in threads) some parts. I think making the main thread hanging a minute is not a desired behavior :/

And good news, Visual Studio generated me a 20Go report file to tell me only 2 lines of code take 98% of the start time:


![profilerAntiCheat](https://github.com/user-attachments/assets/c0fae2dc-313f-471b-862c-850cda3b180d)

88%:
https://github.com/AlSch092/UltimateAntiCheat/blob/b095897a57c8c685822186057593e6dc9c83c99b/AntiTamper/Integrity.hpp#L47

10%:
https://github.com/AlSch092/UltimateAntiCheat/blob/b095897a57c8c685822186057593e6dc9c83c99b/API/API.cpp#L147

The idea is that these two methods populate variables in their constructor, why not put them in a thread and just add a "isDataReady" boolean flag so that methods needing them can wait/do something else ? this way, even no need of mutexes!

It seems simple to implement (I can do it, but I want your input on the subject):
for `GetUnsignedDrivers`, it's even unused for now, so we can decide what to do.
for `GetModuleHashes`, the content (`Integrity::ModuleHashes`) is only used once, :

https://github.com/AlSch092/UltimateAntiCheat/blob/b095897a57c8c685822186057593e6dc9c83c99b/AntiTamper/Integrity.cpp#L189


https://github.com/AlSch092/UltimateAntiCheat/blob/b095897a57c8c685822186057593e6dc9c83c99b/Detections.cpp#L194

so as it's a monitor main loop check, we could make `IsModuleModified` return "false" while its module list is not initialized, so it will delay only by a few seconds the tamper detection? (and no need for mutexes)

And for the destructors, we could add a boolean to break the `GetModuleHashes` loop in case of premature destruction, and win lot of time when debugging.

(or screw that, we wait for the data to be ready before destructing it, what we want to improve is *boot* time, not closing time, we can debug by Ctrl-C the app and users won't launch their game for less than a minute anyway. ^^' ) 

what do you think of this idea?

also minor nitpick, why is this list a pointer instead of a classic variable?
https://github.com/AlSch092/UltimateAntiCheat/blob/b095897a57c8c685822186057593e6dc9c83c99b/AntiTamper/Integrity.hpp#L107

